### PR TITLE
HoloLens 2 and Task Support

### DIFF
--- a/Assets/MixedRealityToolkit.LightingTools/CameraCapture/CameraCaptureARFoundation.cs
+++ b/Assets/MixedRealityToolkit.LightingTools/CameraCapture/CameraCaptureARFoundation.cs
@@ -4,6 +4,7 @@
 #if USE_ARFOUNDATION
 
 using System;
+using System.Threading.Tasks;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
@@ -12,281 +13,288 @@ using UnityEngine.XR.ARSubsystems;
 
 namespace Microsoft.MixedReality.Toolkit.LightingTools
 {
-	public class CameraCaptureARFoundation : ICameraCapture
-	{
-		/// <summary>Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</summary>
-		private CameraResolution resolution;
-		/// <summary>Texture cache for storing captured images.</summary>
-		private Texture2D        captureTex;
-		/// <summary>Is this ICameraCapture ready for capturing pictures?</summary>
-		private bool             ready = false;
+    /// <summary>
+    /// An <see cref="ICameraCapture"/> service that works with an AR Foundation camera.
+    /// </summary>
+    public class CameraCaptureARFoundation : ICameraCapture
+    {
+        #region Member Variables
+        /// <summary>Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</summary>
+        private CameraResolution resolution;
+        /// <summary>Texture cache for storing captured images.</summary>
+        private Texture2D captureTex;
+        /// <summary>Is this ICameraCapture ready for capturing pictures?</summary>
+        private bool ready = false;
 
         private ARCameraManager cameraManager;
         private Matrix4x4 lastProjMatrix;
         private Matrix4x4 lastDisplayMatrix;
+        #endregion // Member Variables
 
-        /// <summary>
-        /// Is the camera completely initialized and ready to begin taking pictures?
-        /// </summary>
-        public bool  IsReady
-		{
-			get
-			{
-				return ready;
-			}
-		}
-		/// <summary>
-		/// Is the camera currently already busy with taking a picture?
-		/// </summary>
-		public bool  IsRequestingImage
-		{
-			get
-			{
-				return false;
-			}
-		}
-		/// <summary>
-		/// Field of View of the camera in degrees. This value is never ready until after 
-		/// initialization, and in many cases, isn't accurate until after a picture has
-		/// been taken. It's best to check this after each picture if you need it.
-		/// </summary>
-		public float FieldOfView
-		{
-			get
-			{
-				float fov = Mathf.Atan(1.0f / lastProjMatrix[1,1] ) * 2.0f * Mathf.Rad2Deg;
-				return fov;
-			}
-		}
-
-		/// <summary>
-		/// Starts up and selects a device's camera, and finds appropriate picture settings
-		/// based on the provided resolution! 
-		/// </summary>
-		/// <param name="preferGPUTexture">Do you prefer GPU textures, or do you prefer a NativeArray of colors? Certain optimizations may be present to take advantage of this preference.</param>
-		/// <param name="resolution">Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</param>
-		/// <param name="onInitialized">When the camera is initialized, this callback is called! Some cameras may return immediately, others may take a while. Can be null.</param>
-		public void Initialize(bool aPreferGPUTexture, CameraResolution aResolution, Action aOnInitialized)
-		{
-			resolution = aResolution;
-            lastProjMatrix = Matrix4x4.identity;
-            lastDisplayMatrix = Matrix4x4.identity;
-
-            Action<ARSessionStateChangedEventArgs> handler = null;
-			handler = (aState) =>
-			{
-				// Camera and orientation data aren't ready until ARFoundation is actually tracking!
-				if (aState.state == ARSessionState.SessionTracking)
-				{
-                    ARSession.stateChanged -= handler;
-					ready = true;
-					if (aOnInitialized != null)
-					{
-						aOnInitialized();
-					}
-				}
-			};
-            ARSession.stateChanged += handler;
-            
-            cameraManager = GameObject.FindObjectOfType<ARCameraManager>();
-            if (cameraManager == null) { 
-                Debug.LogError("CameraCapture needs an ARCameraManager to be present in the scene!");
-                return;
-            }
-            cameraManager.frameReceived += OnFrameReceived;
-        }
-		
-        void OnFrameReceived(ARCameraFrameEventArgs args)
+        #region Overrides / Event Handlers
+        private void OnFrameReceived(ARCameraFrameEventArgs args)
         {
             if (args.projectionMatrix.HasValue)
                 lastProjMatrix = args.projectionMatrix.Value;
             if (args.displayMatrix.HasValue)
                 lastDisplayMatrix = args.displayMatrix.Value;
         }
+        #endregion // Overrides / Event Handlers
 
-		/// <summary>
-		/// Gets the image data from ARFoundation, preps it, and drops it into captureTex.
-		/// </summary>
-		/// <param name="aOnFinished">Gets called when this method is finished with getting the image.</param>
-		private void GrabScreen(Action aOnFinished)
-		{
-            
+        #region Public Methods
+        /// <inheritdoc/>
+        public Task InitializeAsync(bool preferGPUTexture, CameraResolution preferredResolution)
+        {
+            // Store values
+            resolution = preferredResolution;
+            lastProjMatrix = Matrix4x4.identity;
+            lastDisplayMatrix = Matrix4x4.identity;
+
+            // Before moving on, make sure we have an AR camera manager
+            cameraManager = GameObject.FindObjectOfType<ARCameraManager>();
+            if (cameraManager == null)
+            {
+                throw new InvalidOperationException("CameraCapture needs an ARCameraManager to be present in the scene!");
+            }
+
+            // Subscribe to camera frame changes
+            cameraManager.frameReceived += OnFrameReceived;
+
+            // Create a completion source to handle AR Foundation initializing asynchronously
+            TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
+
+            // Create a handler for the AR Session to start
+            Action<ARSessionStateChangedEventArgs> handler = null;
+            handler = (aState) =>
+            {
+                // Camera and orientation data aren't ready until ARFoundation is actually tracking!
+                if (aState.state == ARSessionState.SessionTracking)
+                {
+                    // Now that we're tracking, the handler is no longer needed
+                    ARSession.stateChanged -= handler;
+
+                    // And we're ready
+                    ready = true;
+
+                    // Signal complete
+                    tcs.SetResult(true);
+                }
+            };
+
+            // Subscribe to session state changes
+            ARSession.stateChanged += handler;
+
+            // Return the completion source task to allow someone to await initialization
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Gets the image data from ARFoundation, preps it, and drops it into captureTex.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> that yields <c>true</c> if the capture was successful; otherwise <c>false</c>.
+        /// </returns>
+        private Task<bool> GrabScreenAsync()
+        {
             // Grab the latest image from ARFoundation
             XRCameraImage image;
-			if (!cameraManager.TryGetLatestImage(out image))
-			{
-				Debug.LogError("[CameraCaptureARFoundation] Could not get latest image!");
-				return;
-			}
-			
-			// Set up resizing parameters
-			Vector2Int size = resolution.AdjustSize(new Vector2Int( image.width, image.height ));
-			var conversionParams = new XRCameraImageConversionParams
-			{
-				inputRect        = new RectInt(0, 0, image.width, image.height),
-				outputDimensions = new Vector2Int(size.x, size.y),
-				outputFormat     = TextureFormat.RGB24,
-				transformation   = CameraImageTransformation.MirrorY,
-			};
-			
-			// make sure we have a texture to store the resized image
-			if (captureTex == null || captureTex.width != size.x || captureTex.height != size.y)
-			{
-				if (captureTex != null)
-				{
-					GameObject.Destroy(captureTex);
-				}
-				captureTex = new Texture2D(size.x, size.y, TextureFormat.RGB24, false);
-			}
-			
-			// And do the resize!
-			image.ConvertAsync(conversionParams, (status, p, data) =>
-			{
-				if (status == AsyncCameraImageConversionStatus.Ready) {
-					captureTex.LoadRawTextureData(data);
-					captureTex.Apply();
-				}
-				if (status == AsyncCameraImageConversionStatus.Ready || status == AsyncCameraImageConversionStatus.Failed) {
-					image.Dispose();
-					aOnFinished();
-				}
-			});
-		}
+            if (!cameraManager.TryGetLatestImage(out image))
+            {
+                Debug.LogError("[CameraCaptureARFoundation] Could not get latest image!");
+                Task.FromResult<bool>(false);
+            }
 
-		/// <summary>
-		/// Gets the camera's current transform in Unity coordinates, including any magic or trickery for offsets from ARFoundation.
-		/// </summary>
-		/// <returns>Camera's current transform in Unity coordinates.</returns>
-		private Matrix4x4 GetCamTransform()
-		{
-			Matrix4x4 matrix = lastDisplayMatrix;
+            // Set up resizing parameters
+            Vector2Int size = resolution.AdjustSize(new Vector2Int(image.width, image.height));
+            var conversionParams = new XRCameraImageConversionParams
+            {
+                inputRect = new RectInt(0, 0, image.width, image.height),
+                outputDimensions = new Vector2Int(size.x, size.y),
+                outputFormat = TextureFormat.RGB24,
+                transformation = CameraImageTransformation.MirrorY,
+            };
 
-			// This matrix transforms a 2D UV coordinate based on the device's orientation.
-			// It will rotate, flip, but maintain values in the 0-1 range. This is technically
-			// just a 3x3 matrix stored in a 4x4
+            // make sure we have a texture to store the resized image
+            if (captureTex == null || captureTex.width != size.x || captureTex.height != size.y)
+            {
+                if (captureTex != null)
+                {
+                    GameObject.Destroy(captureTex);
+                }
+                captureTex = new Texture2D(size.x, size.y, TextureFormat.RGB24, false);
+            }
 
-			// These are the matrices provided in specific phone orientations:
+            // Create a completion source to wait for the async operation
+            TaskCompletionSource<bool> tcs = new TaskCompletionSource<bool>();
 
-			#if UNITY_ANDROID
+            // And do the resize!
+            image.ConvertAsync(conversionParams, (status, p, data) =>
+            {
+                if (status == AsyncCameraImageConversionStatus.Ready)
+                {
+                    captureTex.LoadRawTextureData(data);
+                    captureTex.Apply();
+                }
+                if (status == AsyncCameraImageConversionStatus.Ready || status == AsyncCameraImageConversionStatus.Failed)
+                {
+                    image.Dispose();
 
-			// 1 0 0 Landscape Left (upside down)
-			// 0 1 0
-			// 0 0 0 
-			if (Mathf.RoundToInt(matrix[0,0]) == 1 && Mathf.RoundToInt(matrix[1,1]) == 1)
-			{
-				matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,180) );
-			}
+                    // TODO: Should we log the failure or fail the task? Previously this completed no matter what.
+                    tcs.SetResult(status == AsyncCameraImageConversionStatus.Ready);
+                }
+            });
 
-			//-1 0 1 Landscape Right
-			// 0-1 1
-			// 0 0 0
-			else if (Mathf.RoundToInt(matrix[0,0]) == -1 && Mathf.RoundToInt(matrix[1,1]) == -1)
-			{
-				matrix = Matrix4x4.identity;
-			}
+            // Return the completion source task so callers can await
+            return tcs.Task;
+        }
 
-			// 0 1 0 Portrait
-			//-1 0 1
-			// 0 0 0
-			else if (Mathf.RoundToInt(matrix[0,1]) == 1 && Mathf.RoundToInt(matrix[1,0]) == -1)
-			{
-				matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,90) );
-			}
+        /// <summary>
+        /// Gets the camera's current transform in Unity coordinates, including any magic or trickery for offsets from ARFoundation.
+        /// </summary>
+        /// <returns>Camera's current transform in Unity coordinates.</returns>
+        private Matrix4x4 GetCamTransform()
+        {
+            Matrix4x4 matrix = lastDisplayMatrix;
 
-			// 0-1 1 Portrait (upside down)
-			// 1 0 0
-			// 0 0 0
-			else if (Mathf.RoundToInt(matrix[0,1]) == -1 && Mathf.RoundToInt(matrix[1,0]) == 1)
-			{
-				matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,-90) );
-			}
+            // This matrix transforms a 2D UV coordinate based on the device's orientation.
+            // It will rotate, flip, but maintain values in the 0-1 range. This is technically
+            // just a 3x3 matrix stored in a 4x4
 
-			#elif UNITY_IOS
+            // These are the matrices provided in specific phone orientations:
 
-			// 0-.6 0 Portrait
-			//-1  1 0 The source image is upside down as well, so this is identity
-			// 1 .8 1 
-			if (Mathf.RoundToInt(matrix[0,0]) == 0)
-			{
-				matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,90) );
-			}
+            #if UNITY_ANDROID
 
-			//-1  0 0 Landscape Right
-			// 0 .6 0
-			// 1 .2 1
-			else if (Mathf.RoundToInt(matrix[0,0]) == -1)
-			{
-				matrix = Matrix4x4.identity;
-			}
+            // 1 0 0 Landscape Left (upside down)
+            // 0 1 0
+            // 0 0 0
+            if (Mathf.RoundToInt(matrix[0,0]) == 1 && Mathf.RoundToInt(matrix[1,1]) == 1)
+            {
+                matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,180) );
+            }
 
-			// 1  0 0 Landscape Left
-			// 0-.6 0
-			// 0 .8 1
-			else if (Mathf.RoundToInt(matrix[0,0]) == 1)
-			{
-				matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,180) );
-			}
+            //-1 0 1 Landscape Right
+            // 0-1 1
+            // 0 0 0
+            else if (Mathf.RoundToInt(matrix[0,0]) == -1 && Mathf.RoundToInt(matrix[1,1]) == -1)
+            {
+                matrix = Matrix4x4.identity;
+            }
 
-			// iOS has no upside down?
-			#else
+            // 0 1 0 Portrait
+            //-1 0 1
+            // 0 0 0
+            else if (Mathf.RoundToInt(matrix[0,1]) == 1 && Mathf.RoundToInt(matrix[1,0]) == -1)
+            {
+                matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,90) );
+            }
 
-			if (true)
-			{
-			}
-			#endif
-			
-			else
-			{
-				#pragma warning disable 0162
-				Debug.LogWarningFormat("Unexpected Matrix provided from ARFoundation!\n{0}", matrix.ToString());
-				#pragma warning restore 0162
-			}
-			
-			return Camera.main.transform.localToWorldMatrix * matrix;
-		}
-		
-		/// <summary>
-		/// Request an image from the camera, and provide it as an array of colors on the CPU!
-		/// </summary>
-		/// <param name="onImageAcquired">This is the function that will be called when the image is ready. Matrix is the transform of the device when the picture was taken, and integers are width and height of the NativeArray.</param>
-		public void RequestImage(Action<NativeArray<Color24>, Matrix4x4, int, int> aOnImageAcquired)
-		{
-			Matrix4x4 transform = GetCamTransform();
-			GrabScreen(()=>
-			{ 
-				if (aOnImageAcquired != null)
-				{
-					aOnImageAcquired(captureTex.GetRawTextureData<Color24>(), transform, captureTex.width, captureTex.height);
-				}
-			});
-		}
-		/// <summary>
-		/// Request an image from the camera, and provide it as a GPU Texture!
-		/// </summary>
-		/// <param name="onImageAcquired">This is the function that will be called when the image is ready. Texture is not guaranteed to be a Texture2D, could also be a WebcamTexture. Matrix is the transform of the device when the picture was taken.</param>
-		public void RequestImage(Action<Texture, Matrix4x4> aOnImageAcquired)
-		{
-			Matrix4x4 transform = GetCamTransform();
-			GrabScreen(()=>
-			{
-				if (aOnImageAcquired != null)
-				{
-					aOnImageAcquired(captureTex, transform);
-				}
-			});
-		}
+            // 0-1 1 Portrait (upside down)
+            // 1 0 0
+            // 0 0 0
+            else if (Mathf.RoundToInt(matrix[0,1]) == -1 && Mathf.RoundToInt(matrix[1,0]) == 1)
+            {
+                matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,-90) );
+            }
 
-		/// <summary>
-		/// Done with the camera, free up resources!
-		/// </summary>
-		public void Shutdown()
-		{
-			if (captureTex != null)
-			{
-				GameObject.Destroy(captureTex);
-			}
-		}
-	}
+            #elif UNITY_IOS
+
+            // 0-.6 0 Portrait
+            //-1  1 0 The source image is upside down as well, so this is identity
+            // 1 .8 1
+            if (Mathf.RoundToInt(matrix[0,0]) == 0)
+            {
+                matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,90) );
+            }
+
+            //-1  0 0 Landscape Right
+            // 0 .6 0
+            // 1 .2 1
+            else if (Mathf.RoundToInt(matrix[0,0]) == -1)
+            {
+                matrix = Matrix4x4.identity;
+            }
+
+            // 1  0 0 Landscape Left
+            // 0-.6 0
+            // 0 .8 1
+            else if (Mathf.RoundToInt(matrix[0,0]) == 1)
+            {
+                matrix = Matrix4x4.Rotate( Quaternion.Euler(0,0,180) );
+            }
+
+            // iOS has no upside down?
+            #else
+
+            if (true)
+            {
+            }
+            #endif
+
+            else
+            {
+#pragma warning disable 0162
+                Debug.LogWarningFormat("Unexpected Matrix provided from ARFoundation!\n{0}", matrix.ToString());
+#pragma warning restore 0162
+            }
+
+            return Camera.main.transform.localToWorldMatrix * matrix;
+        }
+
+        /// <inheritdoc/>
+        public async Task<ColorResult> RequestColorAsync()
+        {
+            Matrix4x4 transform = GetCamTransform();
+            await GrabScreenAsync();
+            return new ColorResult(transform, captureTex);
+        }
+
+        /// <inheritdoc/>
+        public async Task<TextureResult> RequestTextureAsync()
+        {
+            Matrix4x4 transform = GetCamTransform();
+            await GrabScreenAsync();
+            return new TextureResult(transform, captureTex);
+        }
+
+        /// <inheritdoc/>
+        public void Shutdown()
+        {
+            if (captureTex != null)
+            {
+                GameObject.Destroy(captureTex);
+            }
+        }
+        #endregion // Public Methods
+
+        #region Public Properties
+        /// <inheritdoc/>
+        public float FieldOfView
+        {
+            get
+            {
+                float fov = Mathf.Atan(1.0f / lastProjMatrix[1, 1]) * 2.0f * Mathf.Rad2Deg;
+                return fov;
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsReady
+        {
+            get
+            {
+                return ready;
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsRequestingImage
+        {
+            get
+            {
+                return false;
+            }
+        }
+        #endregion // Public Properties
+    }
 }
-
 #endif

--- a/Assets/MixedRealityToolkit.LightingTools/CameraCapture/CameraCaptureScreen.cs
+++ b/Assets/MixedRealityToolkit.LightingTools/CameraCapture/CameraCaptureScreen.cs
@@ -2,152 +2,144 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Unity.Collections;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.LightingTools
 {
-	public class CameraCaptureScreen : ICameraCapture
-	{
-		/// <summary>Which screen are we rendering?</summary>
-		private Camera           sourceCamera;
-		/// <summary>Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</summary>
-		private CameraResolution resolution;
-		/// <summary>Cache tex for storing the screen.</summary>
-		private Texture2D        captureTex  = null;
-		/// <summary>Is this ICameraCapture ready for capturing pictures?</summary>
-		private bool             ready       = false;
-		/// <summary>For controlling which render layers get rendered for this capture.</summary>
-		private int              renderMask  = ~(1 << 31);
+    /// <summary>
+    /// An <see cref="ICameraCapture"/> service that works with Screen Capture.
+    /// </summary>
+    public class CameraCaptureScreen : ICameraCapture
+    {
+        #region Member Variables
+        /// <summary>Which screen are we rendering?</summary>
+        private Camera sourceCamera;
+        /// <summary>Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</summary>
+        private CameraResolution resolution;
+        /// <summary>Cache tex for storing the screen.</summary>
+        private Texture2D captureTex = null;
+        /// <summary>Is this ICameraCapture ready for capturing pictures?</summary>
+        private bool ready = false;
+        /// <summary>For controlling which render layers get rendered for this capture.</summary>
+        private int renderMask = ~(1 << 31);
+        #endregion // Member Variables
 
-		/// <summary>
-		/// Is the camera completely initialized and ready to begin taking pictures?
-		/// </summary>
-		public bool  IsReady
-		{
-			get
-			{
-				return ready;
-			}
-		}
-		/// <summary>
-		/// Is the camera currently already busy with taking a picture?
-		/// </summary>
-		public bool  IsRequestingImage
-		{
-			get
-			{
-				return false;
-			}
-		}
-		/// <summary>
-		/// Field of View of the camera in degrees. This value is never ready until after 
-		/// initialization, and in many cases, isn't accurate until after a picture has
-		/// been taken. It's best to check this after each picture if you need it.
-		/// </summary>
-		public float FieldOfView
-		{
-			get
-			{
-				return Camera.main.fieldOfView;
-			}
-		}
-		
-		/// <param name="aSourceCamera">Which screen are we rendering?</param>
-		/// <param name="aRenderMask">For controlling which render layers get rendered for this capture.</param>
-		public CameraCaptureScreen(Camera aSourceCamera, int aRenderMask = ~(1 << 31))
-		{
-			sourceCamera = aSourceCamera;
-			renderMask   = aRenderMask;
-		}
+        #region Constructors
+        /// <summary>
+        /// Initializes a new <see cref="CameraCaptureScreen"/>.
+        /// </summary>
+        /// <param name="sourceCamera">
+        /// Which screen are we rendering?
+        /// </param>
+        /// <param name="renderMask">
+        /// For controlling which render layers get rendered for this capture.
+        /// </param>
+        public CameraCaptureScreen(Camera sourceCamera, int renderMask = ~(1 << 31))
+        {
+            this.sourceCamera = sourceCamera;
+            this.renderMask = renderMask;
+        }
+        #endregion // Constructors
 
-		/// <summary>
-		/// Starts up and selects a device's camera, and finds appropriate picture settings
-		/// based on the provided resolution! 
-		/// </summary>
-		/// <param name="preferGPUTexture">Do you prefer GPU textures, or do you prefer a NativeArray of colors? Certain optimizations may be present to take advantage of this preference.</param>
-		/// <param name="resolution">Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</param>
-		/// <param name="onInitialized">When the camera is initialized, this callback is called! Some cameras may return immediately, others may take a while. Can be null.</param>
-		public void Initialize(bool aPreferGPUTexture, CameraResolution aResolution, Action aOnInitialized)
-		{
-			resolution  = aResolution;
-			ready = true;
+        #region Internal Methods
+        /// <summary>
+        /// Render the current scene to a texture.
+        /// </summary>
+        /// <param name="aSize">Desired size to render.</param>
+        private void GrabScreen(Vector2Int aSize)
+        {
+            if (captureTex == null || captureTex.width != aSize.x || captureTex.height != aSize.y)
+            {
+                if (captureTex != null)
+                {
+                    GameObject.Destroy(captureTex);
+                }
+                captureTex = new Texture2D(aSize.x, aSize.y, TextureFormat.RGB24, false);
+            }
+            RenderTexture rt = RenderTexture.GetTemporary(aSize.x, aSize.y, 24);
+            int oldMask = sourceCamera.cullingMask;
+            sourceCamera.targetTexture = rt;
+            sourceCamera.cullingMask = renderMask;
+            sourceCamera.Render();
 
-			if (aOnInitialized != null)
-			{
-				aOnInitialized();
-			}
-		}
+            RenderTexture.active = rt;
+            captureTex.ReadPixels(sourceCamera.pixelRect, 0, 0, false);
+            captureTex.Apply();
+            sourceCamera.targetTexture = null;
+            sourceCamera.cullingMask = oldMask;
+            RenderTexture.active = null;
 
-		/// <summary>
-		/// Render the current scene to a texture.
-		/// </summary>
-		/// <param name="aSize">Desired size to render.</param>
-		private void GrabScreen(Vector2Int aSize)
-		{
-			if (captureTex == null || captureTex.width != aSize.x || captureTex.height != aSize.y)
-			{
-				if (captureTex != null)
-				{
-					GameObject.Destroy(captureTex);
-				}
-				captureTex = new Texture2D(aSize.x, aSize.y, TextureFormat.RGB24, false);
-			}
-			RenderTexture rt  = RenderTexture.GetTemporary(aSize.x, aSize.y, 24);
-			int oldMask = sourceCamera.cullingMask;
-			sourceCamera.targetTexture = rt;
-			sourceCamera.cullingMask   = renderMask;
-			sourceCamera.Render();
+            RenderTexture.ReleaseTemporary(rt);
+        }
+        #endregion // Internal Methods
 
-			RenderTexture.active = rt;
-			captureTex.ReadPixels(sourceCamera.pixelRect, 0, 0, false);
-			captureTex.Apply();
-			sourceCamera.targetTexture = null;
-			sourceCamera.cullingMask   = oldMask;
-			RenderTexture.active = null;
+        #region Public Methods
+        /// <inheritdoc/>
+        public Task InitializeAsync(bool preferGPUTexture, CameraResolution preferredResolution)
+        {
+            // Store
+            resolution = preferredResolution;
+            ready = true;
 
-			RenderTexture.ReleaseTemporary(rt);
-		}
+            // Already complete
+            return Task.CompletedTask;
+        }
 
-		/// <summary>
-		/// Request an image from the camera, and provide it as an array of colors on the CPU!
-		/// </summary>
-		/// <param name="onImageAcquired">This is the function that will be called when the image is ready. Matrix is the transform of the device when the picture was taken, and integers are width and height of the NativeArray.</param>
-		public void RequestImage(Action<NativeArray<Color24>, Matrix4x4, int, int> aOnImageAcquired)
-		{
-			Vector2Int size = resolution.AdjustSize(new Vector2Int(sourceCamera.pixelWidth, sourceCamera.pixelHeight));
-			GrabScreen(size);
+        /// <inheritdoc/>
+        public Task<ColorResult> RequestColorAsync()
+        {
+            Vector2Int size = resolution.AdjustSize(new Vector2Int(sourceCamera.pixelWidth, sourceCamera.pixelHeight));
+            GrabScreen(size);
+            return Task.FromResult(new ColorResult(sourceCamera.transform.localToWorldMatrix, captureTex));
+        }
 
-			if (aOnImageAcquired != null)
-			{
-				aOnImageAcquired(captureTex.GetRawTextureData<Color24>(), sourceCamera.transform.localToWorldMatrix, size.x, size.y);
-			}
-		}
+        /// <inheritdoc/>
+        public Task<TextureResult> RequestTextureAsync()
+        {
+            Vector2Int size = resolution.AdjustSize(new Vector2Int(sourceCamera.pixelWidth, sourceCamera.pixelHeight));
+            GrabScreen(size);
+            return Task.FromResult(new TextureResult(sourceCamera.transform.localToWorldMatrix, captureTex));
+        }
 
-		/// <summary>
-		/// Request an image from the camera, and provide it as a GPU Texture!
-		/// </summary>
-		/// <param name="onImageAcquired">This is the function that will be called when the image is ready. Texture is not guaranteed to be a Texture2D, could also be a WebcamTexture. Matrix is the transform of the device when the picture was taken.</param>
-		public void RequestImage(Action<Texture, Matrix4x4> aOnImageAcquired)
-		{
-			Vector2Int size = resolution.AdjustSize(new Vector2Int(sourceCamera.pixelWidth, sourceCamera.pixelHeight));
-			GrabScreen(size);
+        /// <inheritdoc/>
+        public void Shutdown()
+        {
+            if (captureTex != null)
+            {
+                GameObject.Destroy(captureTex);
+            }
+        }
+        #endregion // Public Methods
 
-			if (aOnImageAcquired != null)
-			{
-				aOnImageAcquired(captureTex, sourceCamera.transform.localToWorldMatrix);
-			}
-		}
+        #region Public Properties
+        /// <inheritdoc/>
+        public float FieldOfView
+        {
+            get
+            {
+                return Camera.main.fieldOfView;
+            }
+        }
 
-		/// <summary>
-		/// Done with the camera, free up resources!
-		/// </summary>
-		public void Shutdown()
-		{
-			if (captureTex != null)
-			{
-				GameObject.Destroy(captureTex);
-			}
-		}
-	}
+        /// <inheritdoc/>
+        public bool IsReady
+        {
+            get
+            {
+                return ready;
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsRequestingImage
+        {
+            get
+            {
+                return false;
+            }
+        }
+        #endregion // Public Properties
+    }
 }

--- a/Assets/MixedRealityToolkit.LightingTools/CameraCapture/CameraCaptureWebcam.cs
+++ b/Assets/MixedRealityToolkit.LightingTools/CameraCapture/CameraCaptureWebcam.cs
@@ -2,163 +2,178 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Unity.Collections;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.LightingTools
 {
-	public class CameraCaptureWebcam : ICameraCapture
-	{
-		/// <summary> A transform to reference for the position of the camera. </summary>
-		private Transform        poseSource     = null;
-		/// <summary> The WebCamTexture we're using to get a webcam image. </summary>
-		private WebCamTexture    webcamTex      = null;
-		/// <summary> Webcam device that we picked to read from. </summary>
-		private WebCamDevice     device;
-		/// <summary> When was this created? WebCamTexture isn't ready right way, so we'll need to wait a bit.</summary>
-		private float            startTime      = 0;
-		/// <summary> What field of view should this camera report? </summary>
-		private float            fieldOfView    = 45;
-		/// <summary>Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</summary>
-		private CameraResolution resolution     = null;
-		/// <summary>Cache tex for storing the final image.</summary>
-		private Texture          resizedTexture = null;
+    /// <summary>
+    /// An <see cref="ICameraCapture"/> service that works with a regular webcam.
+    /// </summary>
+    public class CameraCaptureWebcam : ICameraCapture
+    {
+        #region Constants
+        /// <summary>
+        /// The amount of time to wait for a webcam to initialize before frames are served.
+        /// </summary>
+        /// <remarks>
+        /// This delay is necessary because some webcams can take several seconds to fully initialize before sending valid frames.
+        /// During this time, many webcams will simply send a black frame. If LightCapture is in Single Frame mode, this will result
+        /// in the scene being unlit. Unfortunately there is no know way to query for the webcam to be fully initialized.
+        /// </remarks>
+        private const float CAMERA_START_DELAY = 2.0f;
+        #endregion // Constants
 
-		/// <summary>
-		/// Is the camera completely initialized and ready to begin taking pictures?
-		/// </summary>
-		public bool  IsReady
-		{
-			get
-			{
-				return webcamTex != null && webcamTex.isPlaying && (Time.time - startTime) > 0.5f;
-			}
-		}
-		/// <summary>
-		/// Is the camera currently already busy with taking a picture?
-		/// </summary>
-		public bool  IsRequestingImage
-		{
-			get;
-			private set;
-		}
-		/// <summary>
-		/// Field of View of the camera in degrees. This value is never ready until after 
-		/// initialization, and in many cases, isn't accurate until after a picture has
-		/// been taken. It's best to check this after each picture if you need it.
-		/// </summary>
-		public float FieldOfView
-		{
-			get
-			{
-				return fieldOfView;
-			}
-		}
+        #region Member Variables
+        /// <summary> A transform to reference for the position of the camera. </summary>
+        private Transform poseSource = null;
+        /// <summary> The WebCamTexture we're using to get a webcam image. </summary>
+        private WebCamTexture webcamTex = null;
+        /// <summary> Webcam device that we picked to read from. </summary>
+        private WebCamDevice device;
+        /// <summary> When was this created? WebCamTexture isn't ready right way, so we'll need to wait a bit.</summary>
+        private float startTime = 0;
+        /// <summary> What field of view should this camera report? </summary>
+        private float fieldOfView = 45;
+        /// <summary>Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</summary>
+        private CameraResolution resolution = null;
+        /// <summary>Cache texture for storing the final image.</summary>
+        private Texture resizedTexture = null;
+        #endregion // Member Variables
 
-		public CameraCaptureWebcam(Transform aPoseSource, float aFieldOfView)
-		{
-			poseSource  = aPoseSource;
-			fieldOfView = aFieldOfView;
-		}
+        #region Constructors
+        /// <summary>
+        /// Initializes a new <see cref="CameraCaptureWebcam"/>.
+        /// </summary>
+        /// <param name="poseSource">
+        /// The transform that serves as the origin and pose of the camera.
+        /// </param>
+        /// <param name="fieldOfView">
+        /// The field of view of the camera.
+        /// </param>
+        public CameraCaptureWebcam(Transform poseSource, float fieldOfView)
+        {
+            this.poseSource = poseSource;
+            this.fieldOfView = fieldOfView;
+        }
+        #endregion // Constructors
 
-		/// <summary>
-		/// Starts up and selects a device's camera, and finds appropriate picture settings
-		/// based on the provided resolution! 
-		/// </summary>
-		/// <param name="preferGPUTexture">Do you prefer GPU textures, or do you prefer a NativeArray of colors? Certain optimizations may be present to take advantage of this preference.</param>
-		/// <param name="resolution">Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</param>
-		/// <param name="onInitialized">When the camera is initialized, this callback is called! Some cameras may return immediately, others may take a while. Can be null.</param>
-		public void Initialize(bool aPreferGPUTexture, CameraResolution aResolution, Action aOnInitialized)
-		{
-			if (webcamTex != null)
-			{
-				throw new Exception("[CameraCapture] Only need to initialize once!");
-			}
-			// No cameras? Ditch out!
-			if (WebCamTexture.devices.Length <= 0)
-			{
-				return;
-			}
+        #region Public Methods
+        /// <inheritdoc/>
+        public async Task InitializeAsync(bool preferGPUTexture, CameraResolution preferredResolution)
+        {
+            // Avoid double initialization
+            if (webcamTex != null)
+            {
+                throw new InvalidOperationException($"{nameof(CameraCaptureWebcam)} {nameof(InitializeAsync)} should only be called once unless it is shut down.");
+            }
 
-			resolution = aResolution;
+            // No cameras? Ditch out!
+            if (WebCamTexture.devices.Length <= 0)
+            {
+                Debug.LogWarning($"Could not initialize {nameof(CameraCaptureWebcam)} because there are no webcams attached to the system.");
+                return;
+            }
 
-			// Find a rear facing camera we can use, or use the first one
-			WebCamDevice[] devices = WebCamTexture.devices;
-			device = devices[0];
-			for (int i = 0; i < devices.Length; i++)
-			{
-				if (!devices[i].isFrontFacing || devices[i].name.ToLower().Contains("rear"))
-				{
-					device = devices[i];
-				}
-			}
-		
-			// Pick a camera resolution
-			if (resolution.nativeResolution == NativeResolutionMode.Largest)
-			{
-				webcamTex = new WebCamTexture(device.name, 10000, 10000, 2);
-			}
-			else if (resolution.nativeResolution == NativeResolutionMode.Smallest)
-			{
-				webcamTex = new WebCamTexture(device.name, 1, 1, 2);
-			}
-			else if (resolution.nativeResolution == NativeResolutionMode.Closest)
-			{
-				webcamTex = new WebCamTexture(device.name, resolution.size.x, resolution.size.y, 2);
-			}
-			else
-			{
-				throw new NotImplementedException(resolution.nativeResolution.ToString());
-			}
-			
-			webcamTex.Play();
-		
-			if (aOnInitialized != null)
-			{
-				aOnInitialized();
-			}
-			startTime = Time.time;
-		}
+            // Store parameters
+            resolution = preferredResolution;
 
-		/// <summary>
-		/// Request an image from the camera, and provide it as an array of colors on the CPU!
-		/// </summary>
-		/// <param name="onImageAcquired">This is the function that will be called when the image is ready. Matrix is the transform of the device when the picture was taken, and integers are width and height of the NativeArray.</param>
-		public void RequestImage(Action<NativeArray<Color24>, Matrix4x4, int, int> aOnImageAcquired)
-		{
-			resolution.ResizeTexture(webcamTex, ref resizedTexture, true);
-			NativeArray<Color24> pixels = ((Texture2D)resizedTexture).GetRawTextureData<Color24>();// _resizedTexture is Texture2D ? ((Texture2D)_resizedTexture).GetPixels32() : ((WebCamTexture)_resizedTexture).GetPixels32();
+            // Find a rear facing camera we can use, or use the first one
+            WebCamDevice[] devices = WebCamTexture.devices;
+            device = devices[0];
+            for (int i = 0; i < devices.Length; i++)
+            {
+                if (!devices[i].isFrontFacing || devices[i].name.ToLower().Contains("rear"))
+                {
+                    device = devices[i];
+                }
+            }
 
-			if (aOnImageAcquired != null)
-			{
-				aOnImageAcquired(pixels, poseSource == null ? Matrix4x4.identity : poseSource.localToWorldMatrix, resizedTexture.width, resizedTexture.height);
-			}
-		}
+            // Pick a camera resolution
+            if (resolution.nativeResolution == NativeResolutionMode.Largest)
+            {
+                webcamTex = new WebCamTexture(device.name, 10000, 10000, 2);
+            }
+            else if (resolution.nativeResolution == NativeResolutionMode.Smallest)
+            {
+                webcamTex = new WebCamTexture(device.name, 1, 1, 2);
+            }
+            else if (resolution.nativeResolution == NativeResolutionMode.Closest)
+            {
+                webcamTex = new WebCamTexture(device.name, resolution.size.x, resolution.size.y, 2);
+            }
+            else
+            {
+                throw new NotImplementedException(resolution.nativeResolution.ToString());
+            }
 
-		/// <summary>
-		/// Request an image from the camera, and provide it as a GPU Texture!
-		/// </summary>
-		/// <param name="onImageAcquired">This is the function that will be called when the image is ready. Texture is not guaranteed to be a Texture2D, could also be a WebcamTexture. Matrix is the transform of the device when the picture was taken.</param>
-		public void RequestImage(Action<Texture, Matrix4x4> aOnImageAcquired)
-		{
-			resolution.ResizeTexture(webcamTex, ref resizedTexture, false);
+            // Start the webcam playing
+            webcamTex.Play();
 
-			if (aOnImageAcquired != null)
-			{
-				aOnImageAcquired(resizedTexture, poseSource == null ? Matrix4x4.identity : poseSource.localToWorldMatrix);
-			}
-		}
+            // Bookmark the start time
+            startTime = Time.time;
 
-		/// <summary>
-		/// Done with the camera, free up resources!
-		/// </summary>
-		public void Shutdown()
-		{
-			if (webcamTex != null && webcamTex.isPlaying)
-			{
-				webcamTex.Stop();
-			}
-			webcamTex = null;
-		}
-	}
+            // Wait for camera to initialize
+            await Task.Delay(TimeSpan.FromSeconds(CAMERA_START_DELAY));
+        }
+
+        /// <inheritdoc/>
+        public Task<ColorResult> RequestColorAsync()
+        {
+            resolution.ResizeTexture(webcamTex, ref resizedTexture, true);
+            Texture2D t2d = resizedTexture as Texture2D;
+            if (t2d != null)
+            {
+                return Task.FromResult(new ColorResult(poseSource == null ? Matrix4x4.identity : poseSource.localToWorldMatrix, t2d));
+            }
+            throw new NotSupportedException("This device does not support requesting colors.");
+        }
+
+        /// <inheritdoc/>
+        public Task<TextureResult> RequestTextureAsync()
+        {
+            resolution.ResizeTexture(webcamTex, ref resizedTexture, false);
+            TextureResult result = new TextureResult(poseSource == null ? Matrix4x4.identity : poseSource.localToWorldMatrix, resizedTexture);
+            return Task.FromResult(result);
+        }
+
+        /// <inheritdoc/>
+        public void Shutdown()
+        {
+            if (webcamTex != null && webcamTex.isPlaying)
+            {
+                webcamTex.Stop();
+            }
+            webcamTex = null;
+        }
+        #endregion // Public Methods
+
+        #region Public Properties
+        /// <inheritdoc/>
+        public float FieldOfView
+        {
+            get
+            {
+                return fieldOfView;
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsReady
+        {
+            get
+            {
+                return webcamTex != null && webcamTex.isPlaying && (Time.time - startTime) > CAMERA_START_DELAY;
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsRequestingImage
+        {
+            get;
+            private set;
+        }
+        #endregion // Public Properties
+    }
 }

--- a/Assets/MixedRealityToolkit.LightingTools/CameraCapture/ICameraCapture.cs
+++ b/Assets/MixedRealityToolkit.LightingTools/CameraCapture/ICameraCapture.cs
@@ -2,50 +2,144 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Unity.Collections;
 using UnityEngine;
 
 namespace Microsoft.MixedReality.Toolkit.LightingTools
 {
-	public interface ICameraCapture
-	{
-		/// <summary>
-		/// Is the camera completely initialized and ready to begin taking pictures?
-		/// </summary>
-		bool  IsReady           { get; }
-		/// <summary>
-		/// Is the camera currently already busy with taking a picture?
-		/// </summary>
-		bool  IsRequestingImage { get; }
-		/// <summary>
-		/// Field of View of the camera in degrees. This value is never ready until after 
-		/// initialization, and in many cases, isn't accurate until after a picture has
-		/// been taken. It's best to check this after each picture if you need it.
-		/// </summary>
-		float FieldOfView       { get; }
+    /// <summary>
+    /// The result of a camera capture as colors.
+    /// </summary>
+    public class ColorResult : TextureResult
+    {
+        /// <summary>
+        /// Initialize a new <see cref="ColorResult"/> from a <see cref="Texture2D"/>.
+        /// </summary>
+        /// <param name="matrix">
+        /// The camera matrix.
+        /// </param>
+        /// <param name="texture">
+        /// The texture.
+        /// </param>
+        public ColorResult(Matrix4x4 matrix, Texture2D texture) : base(matrix, texture)
+        {
+            Colors = texture.GetRawTextureData<Color24>();
+        }
 
-		/// <summary>
-		/// Starts up and selects a device's camera, and finds appropriate picture settings
-		/// based on the provided resolution! 
-		/// </summary>
-		/// <param name="preferGPUTexture">Do you prefer GPU textures, or do you prefer a NativeArray of colors? Certain optimizations may be present to take advantage of this preference.</param>
-		/// <param name="resolution">Preferred resolution for taking pictures, note that resolutions are not guaranteed! Refer to CameraResolution for details.</param>
-		/// <param name="onInitialized">When the camera is initialized, this callback is called! Some cameras may return immediately, others may take a while. Can be null.</param>
-		void Initialize(bool preferGPUTexture, CameraResolution resolution, Action onInitialized);
-		/// <summary>
-		/// Done with the camera, free up resources!
-		/// </summary>
-		void Shutdown();
+        /// <summary>
+        /// Initialize a new <see cref="ColorResult"/> from a <see cref="Texture"/> and a color array.
+        /// </summary>
+        /// <param name="matrix">
+        /// The camera matrix.
+        /// </param>
+        /// <param name="texture">
+        /// The texture.
+        /// </param>
+        /// <param name="colors">
+        /// The manually supplied color array.
+        /// </param>
+        public ColorResult(Matrix4x4 matrix, Texture texture, NativeArray<Color24> colors) : base(matrix, texture)
+        {
+            this.Colors = colors;
+        }
 
-		/// <summary>
-		/// Request an image from the camera, and provide it as an array of colors on the CPU!
-		/// </summary>
-		/// <param name="onImageAcquired">This is the function that will be called when the image is ready. Matrix is the transform of the device when the picture was taken, and integers are width and height of the NativeArray.</param>
-		void RequestImage(Action<NativeArray<Color24>, Matrix4x4, int, int> onImageAcquired);
-		/// <summary>
-		/// Request an image from the camera, and provide it as a GPU Texture!
-		/// </summary>
-		/// <param name="onImageAcquired">This is the function that will be called when the image is ready. Texture is not guaranteed to be a Texture2D, could also be a WebcamTexture. Matrix is the transform of the device when the picture was taken.</param>
-		void RequestImage(Action<Texture,              Matrix4x4> onImageAcquired);
-	}
+        /// <summary>
+        /// Gets the colors for the result.
+        /// </summary>
+        public NativeArray<Color24> Colors { get; }
+    }
+
+    /// <summary>
+    /// The result of a camera capture as a texture.
+    /// </summary>
+    public class TextureResult
+    {
+        /// <summary>
+        /// Initialize a new <see cref="TextureResult"/>.
+        /// </summary>
+        /// <param name="matrix">
+        /// The camera matrix.
+        /// </param>
+        /// <param name="texture">
+        /// The texture.
+        /// </param>
+        public TextureResult(Matrix4x4 matrix, Texture texture)
+        {
+            Matrix = matrix;
+            Texture = texture;
+        }
+
+        /// <summary>
+        /// Gets the camera matrix for the result.
+        /// </summary>
+        public Matrix4x4 Matrix { get; }
+
+        /// <summary>
+        /// Gets the texture for the result.
+        /// </summary>
+        public Texture Texture { get; }
+    }
+
+    /// <summary>
+    /// The interface for a camera capture service.
+    /// </summary>
+    public interface ICameraCapture
+    {
+        #region Public Methods
+        /// <summary>
+        /// Initializes a device's camera and finds appropriate picture settings based on the provided resolution.
+        /// </summary>
+        /// <param name="preferGPUTexture">
+        /// Whether GPU textures are preferred over NativeArray of colors. Certain optimizations may be present to take advantage of this preference.
+        /// </param>
+        /// <param name="preferredResolution">
+        /// Preferred resolution for taking pictures. Note that resolutions are not guaranteed! Refer to CameraResolution for details.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the operation.
+        /// </returns>
+        Task InitializeAsync(bool preferGPUTexture, CameraResolution preferredResolution);
+
+        /// <summary>
+        /// Requests an image from the camera and provide it as a Texture on the GPU and array of Colors on the CPU.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the operation.
+        /// </returns>
+        Task<ColorResult> RequestColorAsync();
+
+        /// <summary>
+        /// Requests an image from the camera and provides it as a Texture on the GPU.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> that yields the <see cref="TextureResult"/>.
+        /// </returns>
+        Task<TextureResult> RequestTextureAsync();
+
+        /// <summary>
+        /// Done with the camera, free up resources!
+        /// </summary>
+        void Shutdown();
+        #endregion // Public Methods
+
+        #region Public Properties
+        /// <summary>
+        /// Is the camera completely initialized and ready to begin taking pictures?
+        /// </summary>
+        bool IsReady { get; }
+
+        /// <summary>
+        /// Is the camera currently already busy with taking a picture?
+        /// </summary>
+        bool IsRequestingImage { get; }
+
+        /// <summary>
+        /// Field of View of the camera in degrees. This value is never ready until after
+        /// initialization, and in many cases, isn't accurate until after a picture has
+        /// been taken. It's best to check this after each picture if you need it.
+        /// </summary>
+        float FieldOfView { get; }
+        #endregion // Public Properties
+    }
 }

--- a/Assets/MixedRealityToolkit.LightingTools/CameraCapture/ICameraControl.cs
+++ b/Assets/MixedRealityToolkit.LightingTools/CameraCapture/ICameraControl.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Unity.Collections;
+using UnityEngine;
+
+namespace Microsoft.MixedReality.Toolkit.LightingTools
+{
+    /// <summary>
+    /// The interface for advanced camera control services.
+    /// </summary>
+    public interface ICameraControl
+    {
+        /// <summary>
+        /// Manually override the camera's exposure.
+        /// </summary>
+        /// <param name="exposure">
+        /// This value can range from 0.0 to 1.0 inclusive. It will be scaled to the devices max exposure range.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the operation.
+        /// </returns>
+        Task SetExposureAsync(double exposure);
+
+        /// <summary>
+        /// Manually override the camera's white balance.
+        /// </summary>
+        /// <param name="temperature">
+        /// White balance temperature in kelvin.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the operation.
+        /// </returns>
+        /// <remarks>
+        /// Though specified in kelvin, not all camera controllers follow the spec exactly.
+        /// </remarks>
+        Task SetWhiteBalanceAsync(uint temperature);
+
+        /// <summary>
+        /// Manually override the camera's ISO.
+        /// </summary>
+        /// <param name="iso">
+        /// Camera's sensitivity to light.
+        /// </param>
+        /// <remarks>
+        /// ISO is similar to gain.
+        /// </remarks>
+        Task SetISOAsync(uint iso);
+    }
+}

--- a/Assets/MixedRealityToolkit.LightingTools/CameraCapture/ICameraControl.cs.meta
+++ b/Assets/MixedRealityToolkit.LightingTools/CameraCapture/ICameraControl.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe1935b9462abe64085b76d1a23be8d4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.LightingTools/CameraCapture/Util/CameraExtensions.cs
+++ b/Assets/MixedRealityToolkit.LightingTools/CameraCapture/Util/CameraExtensions.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine.Windows.WebCam;
+using static UnityEngine.Windows.WebCam.PhotoCapture;
+
+namespace Microsoft.MixedReality.Toolkit.LightingTools
+{
+    /// <summary>
+    /// Return data for the
+    /// <see cref="CameraExtensions.TakePhotoAsync(PhotoCapture, CameraParameters)"/>
+    /// extension method.
+    /// </summary>
+    public class TakePhotoResult
+    {
+        public TakePhotoResult(PhotoCaptureResult captureResult, PhotoCaptureFrame frame)
+        {
+            CaptureResult = captureResult;
+            Frame = frame;
+        }
+
+        /// <summary>
+        /// Gets the camera matrix for the result.
+        /// </summary>
+        public PhotoCaptureResult CaptureResult { get; }
+
+        /// <summary>
+        /// Gets the texture for the result.
+        /// </summary>
+        public PhotoCaptureFrame Frame { get; }
+    }
+
+    static public class CameraExtensions
+    {
+        /// <summary>
+        /// <see cref="PhotoCapture.CreateAsync(bool, OnCaptureResourceCreatedCallback)"/> as a task.
+        /// </summary>
+        /// <param name="camera">
+        /// The <see cref="PhotoCapture"/> camera.
+        /// </param>
+        /// <param name="showHolograms">
+        /// Whether or not to show holograms during capture.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> that yields the created camera.
+        /// </returns>
+        static public Task<PhotoCapture> CreateAsync(bool showHolograms)
+        {
+            // Create a completion source
+            var tcs = new TaskCompletionSource<PhotoCapture>();
+
+            // Start the callback version
+            PhotoCapture.CreateAsync(false, captureObject =>
+            {
+                tcs.SetResult(captureObject);
+            });
+
+            // Return the running task from the completion source
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// <see cref="PhotoCapture.StartPhotoModeAsync(CameraParameters, OnPhotoModeStartedCallback)"/> as a task.
+        /// </summary>
+        /// <param name="camera">
+        /// The <see cref="PhotoCapture"/> camera.
+        /// </param>
+        /// <param name="setupParams">
+        /// The setup parameters.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the operation.
+        /// </returns>
+        static public Task<PhotoCaptureResult> StartPhotoModeAsync(this PhotoCapture camera, CameraParameters setupParams)
+        {
+            // Validate
+            if (camera == null) throw new ArgumentNullException(nameof(camera));
+
+            // Create a completion source
+            var tcs = new TaskCompletionSource<PhotoCaptureResult>();
+
+            // Start the callback version
+            camera.StartPhotoModeAsync(setupParams, startResult =>
+            {
+                if (startResult.success)
+                {
+                    tcs.SetResult(startResult);
+                }
+                else
+                {
+                    tcs.SetException(Marshal.GetExceptionForHR((int)startResult.hResult));
+                }
+            });
+
+            // Return the running task from the completion source
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// <see cref="PhotoCapture.StopPhotoModeAsync(OnPhotoModeStoppedCallback)"/> as a task.
+        /// </summary>
+        /// <param name="camera">
+        /// The <see cref="PhotoCapture"/> camera.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the operation.
+        /// </returns>
+        static public Task<PhotoCaptureResult> StopPhotoModeAsync(this PhotoCapture camera)
+        {
+            // Validate
+            if (camera == null) throw new ArgumentNullException(nameof(camera));
+
+            // Create a completion source
+            var tcs = new TaskCompletionSource<PhotoCaptureResult>();
+
+            // Start the callback version
+            camera.StopPhotoModeAsync(stopResult =>
+            {
+                if (stopResult.success)
+                {
+                    tcs.SetResult(stopResult);
+                }
+                else
+                {
+                    tcs.SetException(Marshal.GetExceptionForHR((int)stopResult.hResult));
+                }
+            });
+
+            // Return the running task from the completion source
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// <see cref="PhotoCapture.TakePhotoAsync(string, PhotoCaptureFileOutputFormat, OnCapturedToDiskCallback)"/> as a task.
+        /// </summary>
+        /// The <see cref="PhotoCapture"/> camera.
+        /// The PhotoCapture camera.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> that represents the operation.
+        /// </returns>
+        static public Task<TakePhotoResult> TakePhotoAsync(this PhotoCapture camera)
+        {
+            // Validate
+            if (camera == null) throw new ArgumentNullException(nameof(camera));
+
+            // Create a completion source
+            var tcs = new TaskCompletionSource<TakePhotoResult>();
+
+            // Start the callback version
+            camera.TakePhotoAsync((captureResult, frame) =>
+            {
+                if (captureResult.success)
+                {
+                    tcs.SetResult(new TakePhotoResult(captureResult, frame));
+                }
+                else
+                {
+                    tcs.SetException(Marshal.GetExceptionForHR((int)captureResult.hResult));
+                }
+            });
+
+            // Return the running task from the completion source
+            return tcs.Task;
+        }
+    }
+}

--- a/Assets/MixedRealityToolkit.LightingTools/CameraCapture/Util/CameraExtensions.cs.meta
+++ b/Assets/MixedRealityToolkit.LightingTools/CameraCapture/Util/CameraExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48981097b878bf048a97bcab5a686060
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MixedRealityToolkit.LightingTools/CameraCapture/Util/VideoDeviceControllerWrapperUWP.cs
+++ b/Assets/MixedRealityToolkit.LightingTools/CameraCapture/Util/VideoDeviceControllerWrapperUWP.cs
@@ -7,105 +7,264 @@ using Unity.Collections;
 using UnityEngine;
 
 using System.Runtime.InteropServices;
-using UnityEngine.XR.WSA.WebCam;
+
 using Windows.Media.Devices;
+using System.Threading.Tasks;
 
 namespace Microsoft.MixedReality.Toolkit.LightingTools
 {
-	/// <summary>
-	/// A wrapper for setting camera exposure settings in UWP.
-	/// </summary>
-	sealed class VideoDeviceControllerWrapperUWP : IDisposable
-	{
-		/// <summary>PhotoCapture native object.</summary>
-		private VideoDeviceController controller = null;
-		/// <summary>IDisposable pattern</summary>
-		private bool                  disposed   = false;
-		
-		/// <param name="unknown">Pointer to a PhotoCapture camera.</param>
-		public VideoDeviceControllerWrapperUWP(IntPtr unknown)
-		{
-			controller = (VideoDeviceController)Marshal.GetObjectForIUnknown(unknown);
-		}
- 
-		~VideoDeviceControllerWrapperUWP()
-		{
-			Dispose(false);
-		}
- 
-		/// <summary>
-		/// Manually override the camera's exposure.
-		/// </summary>
-		/// <param name="exposure">These appear to be imaginary units of some kind. Seems to be integer values around, but not exactly -10 to +10.</param>
-		public void SetExposure(int exposure)
-		{
-			//Debug.LogFormat("({3} : {0}-{1}) +{2}", controller.Exposure.Capabilities.Min, controller.Exposure.Capabilities.Max, controller.Exposure.Capabilities.Step, exposure);
-			if (!controller.Exposure.TrySetAuto(false))
-			{
-				Debug.LogErrorFormat("[{0}] HoloLens locatable camera has failed to set auto exposure off", typeof(VideoDeviceControllerWrapperUWP));
-			}
+    /// <summary>
+    /// A wrapper for setting camera exposure settings in UWP.
+    /// </summary>
+    sealed class VideoDeviceControllerWrapperUWP : IDisposable
+    {
+        /// <summary>PhotoCapture native object.</summary>
+        private VideoDeviceController controller = null;
+        /// <summary>IDisposable pattern</summary>
+        private bool                  disposed   = false;
 
-			if (!controller.Exposure.TrySetValue((double)exposure))
-			{
-				Debug.LogErrorFormat("[{0}] HoloLens locatable camera has failed to set exposure to {1} as requested", typeof(VideoDeviceControllerWrapperUWP), exposure);
-			}
-		}
-		/// <summary>
-		/// Manually override the camera's white balance.
-		/// </summary>
-		/// <param name="kelvin">White balance temperature in kelvin! Also seems a bit arbitrary as to what values it accepts.</param>
-		public void SetWhiteBalance(int kelvin)
-		{
-			if (!controller.WhiteBalance.TrySetAuto(false))
-			{
-				Debug.LogErrorFormat("[{0}] HoloLens locatable camera has failed to set auto WhiteBalance off", typeof(VideoDeviceControllerWrapperUWP));
-			}
+        /// <param name="unknown">Pointer to a PhotoCapture camera.</param>
+        public VideoDeviceControllerWrapperUWP(IntPtr unknown)
+        {
+            controller = (VideoDeviceController)Marshal.GetObjectForIUnknown(unknown);
+        }
 
-			if (!controller.WhiteBalance.TrySetValue((double)kelvin))
-			{
-				Debug.LogErrorFormat("[{0}] HoloLens locatable camera has failed to set WhiteBalance to {1} as requested", typeof(VideoDeviceControllerWrapperUWP), kelvin);
-			}
-		}
-		/// <summary>
-		/// Manually override the camera's ISO.
-		/// </summary>
-		/// <param name="iso">Camera's sensitivity to light, kinda like gain.</param>
-		public void SetISO(int iso)
-		{
-			var task = controller.IsoSpeedControl.SetValueAsync((uint)iso);
-		}
- 
-		/// <summary>
-		/// Dispose of resources!
-		/// </summary>
-		public void Dispose()
-		{
-			Dispose(true);
-			GC.SuppressFinalize(this);
-		}
-		/// <summary>
-		/// Dispose(bool disposing) executes in two distinct scenarios.
+        ~VideoDeviceControllerWrapperUWP()
+        {
+            Dispose(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task SetExposureAsync(double exposure)
+        {
+            // Validate the range
+            if ((exposure < 0.0) || (exposure > 1.0)) { throw new ArgumentOutOfRangeException(nameof(exposure)); }
+
+            // Shortcuts
+            var exp = controller.Exposure;
+            var expc = controller.ExposureControl;
+
+            // Try to use exposure control
+            if (expc.Supported)
+            {
+                // Debug.Log("Setting exposure using ExposureControl.");
+
+                // If not in manual mode, attempt to put it in manual mode
+                if (expc.Auto)
+                {
+                    try
+                    {
+                        await expc.SetAutoAsync(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogError($"{nameof(VideoDeviceControllerWrapperUWP)} failed to set exposure mode to manual using ExposureControl. {ex}");
+                    }
+                }
+
+                // Wrap in case of bad controller implementation
+                try
+                {
+                    // Get total possible exposure range as a TimeSpan
+                    TimeSpan range = (expc.Max - expc.Min);
+
+                    // Convert exposure to part of total time
+                    double exppart = range.TotalMilliseconds * exposure;
+
+                    // Convert exposure to TimeSpan (starting with Minimum and adding to it)
+                    TimeSpan exptarget = expc.Min + TimeSpan.FromMilliseconds(exppart);
+
+                    // Make sure we don't go outside the range
+                    if (exptarget < expc.Min) { exptarget = expc.Min; }
+                    if (exptarget > expc.Max) { exptarget = expc.Max; }
+
+                    // Update the controller
+                    // Debug.Log($"Exposure Values - Min: {expc.Min}, Max: {expc.Max}, Input: {exposure}, Target: {exptarget}");
+                    await expc.SetValueAsync(exptarget);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"{nameof(VideoDeviceControllerWrapperUWP)} failed to set exposure to {exposure}. {ex}");
+                }
+            }
+
+            // Fall back to Exposure
+            else if (exp.Capabilities.Supported)
+            {
+                // Debug.Log("Setting exposure using regular Exposure.");
+
+                // Try to turn off auto exposure
+                if (!exp.TrySetAuto(false))
+                {
+                    Debug.LogError($"{nameof(VideoDeviceControllerWrapperUWP)} failed to turn auto exposure off.");
+                }
+
+                // Get total possible exposure range
+                double range = (exp.Capabilities.Max - exp.Capabilities.Min);
+
+                // Convert exposure to part of total range
+                double exppart = range * exposure;
+
+                // Convert exposure part to a value in exposure range (starting with Minimum and adding to it)
+                double exptarget = exp.Capabilities.Min + exppart;
+
+                // Make sure we don't go outside the range
+                if (exptarget < exp.Capabilities.Min) { exptarget = exp.Capabilities.Min; }
+                if (exptarget > exp.Capabilities.Max) { exptarget = exp.Capabilities.Max; }
+
+                // Update controller
+                // Debug.Log($"Exposure Values - Min: {exp.Capabilities.Min}, Max: {exp.Capabilities.Max}, Input: {exposure}, Target: {exptarget}");
+                if (!exp.TrySetValue(exptarget))
+                {
+                    Debug.LogError($"{nameof(VideoDeviceControllerWrapperUWP)} failed to set exposure to {exposure}.");
+                }
+            }
+
+            // No support
+            else
+            {
+                Debug.LogWarning($"{nameof(VideoDeviceControllerWrapperUWP)} current device does not support setting exposure.");
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task SetWhiteBalanceAsync(uint temperature)
+        {
+            // Get shortcuts
+            var wb = controller.WhiteBalance;
+            var wbc = controller.WhiteBalanceControl;
+
+            // Try WhiteBalanceControl first
+            if (wbc.Supported)
+            {
+                // Debug.Log("Setting white balance using WhiteBalanceControl.");
+
+                // If not in manual mode, attempt to put it in manual mode
+                if (wbc.Preset != ColorTemperaturePreset.Manual)
+                {
+                    try
+                    {
+                        await wbc.SetPresetAsync(ColorTemperaturePreset.Manual);
+                    }
+                    catch (Exception ex)
+                    {
+                        Debug.LogError($"{nameof(VideoDeviceControllerWrapperUWP)} failed to set white balance mode to manual. {ex}");
+                    }
+                }
+
+                // Attempt to set the temperature
+                try
+                {
+                    // Make sure the temperature stays within supported range of the controller
+                    uint wbtarget = Math.Max(wbc.Min, temperature);
+                    wbtarget = Math.Min(wbc.Max, wbtarget);
+
+                    // Update controller
+                    // Debug.Log($"White Balance Values - Min: {wbc.Min}, Max: {wbc.Max}, Input: {temperature}, Target: {wbtarget}");
+                    await wbc.SetValueAsync(wbtarget);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"{nameof(VideoDeviceControllerWrapperUWP)} failed to set white balance to {temperature}. {ex}");
+                }
+            }
+
+            // Fall back to WhiteBalance
+            else if (wb.Capabilities.Supported)
+            {
+                // Debug.Log("Setting white balance using regular WhiteBalance.");
+
+                // Attempt to put it in manual mode
+                if (!wb.TrySetAuto(false))
+                {
+                    Debug.LogError($"{nameof(VideoDeviceControllerWrapperUWP)} failed to turn auto white balance off.");
+                }
+
+                // Make sure the temperature stays within supported range of the controller
+                double wbtarget = Math.Max(wb.Capabilities.Min, temperature);
+                wbtarget = Math.Min(wb.Capabilities.Max, wbtarget);
+
+                // Update controller
+                // Debug.Log($"White Balance Values - Min: {wb.Capabilities.Min}, Max: {wb.Capabilities.Max}, Input: {temperature}, Target: {wbtarget}");
+                if (!wb.TrySetValue(wbtarget))
+                {
+                    Debug.LogError($"{nameof(VideoDeviceControllerWrapperUWP)} failed to set white balance to {temperature}.");
+                }
+            }
+
+            // No support
+            else
+            {
+                Debug.LogWarning($"{nameof(VideoDeviceControllerWrapperUWP)} current device does not support setting white balance.");
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task SetISOAsync(uint iso)
+        {
+            // Shortcuts
+            var isoc = controller.IsoSpeedControl;
+
+            // Only option is IsoSpeedControl
+            if (isoc.Supported)
+            {
+                // Debug.Log("Setting ISO using IsoSpeedControl.");
+
+                // Wrap in case of bad controller implementation
+                try
+                {
+                    // Make sure the temperature stays within supported range of the controller
+                    uint isotarget = Math.Max(isoc.Min, iso);
+                    isotarget = Math.Min(isoc.Max, isotarget);
+
+                    // Update the controller
+                    // Debug.Log($"ISO Values - Min: {isoc.Min}, Max: {isoc.Max}, Input: {iso}, Target: {isotarget}");
+                    await isoc.SetValueAsync(isotarget);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"{nameof(VideoDeviceControllerWrapperUWP)} failed to set ISO to {iso}. {ex}");
+                }
+            }
+
+            // No support
+            else
+            {
+                Debug.LogWarning($"{nameof(VideoDeviceControllerWrapperUWP)} current device does not support ISO speed control.");
+            }
+        }
+
+        /// <summary>
+        /// Dispose of resources!
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Dispose(bool disposing) executes in two distinct scenarios.
         /// If disposing equals true, the method has been called directly
         /// or indirectly by a user's code. Managed and unmanaged resources
         /// can be disposed.
         /// If disposing equals false, the method has been called by the
         /// runtime from inside the finalizer and you should not reference
         /// other objects. Only unmanaged resources can be disposed.
-		/// If that's confusing to you too, maybe read this: https://docs.microsoft.com/en-us/dotnet/api/system.idisposable.dispose
-		/// </summary>
-		public void Dispose(bool disposing)
-		{
-			if (!disposed)
-			{
-				if (controller != null)
-				{
-					Marshal.ReleaseComObject(controller);
-					controller = null;
-				}
-				disposed = true;
-			}
-		}
-	}
+        /// If that's confusing to you too, maybe read this: https://docs.microsoft.com/en-us/dotnet/api/system.idisposable.dispose
+        /// </summary>
+        public void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (controller != null)
+                {
+                    Marshal.ReleaseComObject(controller);
+                    controller = null;
+                }
+                disposed = true;
+            }
+        }
+    }
 }
-
 #endif

--- a/Assets/MixedRealityToolkit.LightingTools/Examples/Scripts/LightPreviewController.cs
+++ b/Assets/MixedRealityToolkit.LightingTools/Examples/Scripts/LightPreviewController.cs
@@ -12,266 +12,279 @@ using UnityEngine.XR.WSA.Input;
 
 namespace Microsoft.MixedReality.Toolkit.LightingTools.Examples
 {
-	public class LightPreviewController : MonoBehaviour
-	{
-		#region Fields
+    public class LightPreviewController : MonoBehaviour
+    {
+        #region Constants
+        private const double EXPOSURE_ADJUST = 0.1;
+        private const double EXPOSURE_MAX = 1.0;
+        private const double EXPOSURE_MIN = 0.0;
+        private const uint WB_ADJUST = 250;
+        #endregion // Constants
+
+        #region Fields
 		#pragma warning disable 414, 649
-		[Header("Scene/asset hooks")]
-		[SerializeField] private GameObject   spheres      = null;
-		[SerializeField] private GameObject   shaderBalls  = null;
-		[SerializeField] private GameObject   cubes        = null;
-		[SerializeField] private GameObject[] spawnPrefabs = null;
+        [Header("Scene/asset hooks")]
+        [SerializeField] private GameObject   spheres      = null;
+        [SerializeField] private GameObject   shaderBalls  = null;
+        [SerializeField] private GameObject   cubes        = null;
+        [SerializeField] private GameObject[] spawnPrefabs = null;
 
-		[Header("Movement Values")]
-		[SerializeField] private float velocityDecay = 4f;
-		[SerializeField] private float moveScale     = 1.5f;
-		[SerializeField] private float maxVelocity   = 1;
-		[SerializeField] private float lerpSpeed     = 4;
-	
-		private Vector3 targetPos;
-		private Vector3 handPos;
-		private bool    pressed;
-		private int     addIndex;
-		private Vector3 handVelocity;
-		private Vector3 lastPos;
-		private float   lastTime;
+        [Header("Movement Values")]
+        [SerializeField] private float velocityDecay = 4f;
+        [SerializeField] private float moveScale     = 1.5f;
+        [SerializeField] private float maxVelocity   = 1;
+        [SerializeField] private float lerpSpeed     = 4;
 
-		private int exposure   = -7;
-		private int whitebalance = 6000;
+        private Vector3 targetPos;
+        private Vector3 handPos;
+        private bool    pressed;
+        private int     addIndex;
+        private Vector3 handVelocity;
+        private Vector3 lastPos;
+        private float   lastTime;
 
-		private LightCapture lightCapture;
-		private Component    tts;
-		private MethodInfo   speakMethod;
+        private double exposure   = 0.2;
+        private uint whitebalance = 6000;
 
-		#if UNITY_EDITOR || WINDOWS_UWP
-		private KeywordRecognizer keywordRecognizer;
-		#endif
+        private LightCapture lightCapture;
+        private Component    tts;
+        private MethodInfo   speakMethod;
+
+        #if UNITY_EDITOR || WINDOWS_UWP
+        private KeywordRecognizer keywordRecognizer;
+        #endif
 		#pragma warning restore 414, 649
-		#endregion
+        #endregion
 
-		private void OnEnable()
-		{
-			#if UNITY_EDITOR || WINDOWS_UWP
-			// Setup hand interaction events
-			InteractionManager.InteractionSourceLost     += SourceLost;
-			InteractionManager.InteractionSourcePressed  += SourcePressed;
-			InteractionManager.InteractionSourceReleased += SourceReleased;
-			InteractionManager.InteractionSourceUpdated  += SourceUpdated;
+        private void OnEnable()
+        {
+            #if UNITY_EDITOR || WINDOWS_UWP
+            // Setup hand interaction events
+            InteractionManager.InteractionSourceLost     += SourceLost;
+            InteractionManager.InteractionSourcePressed  += SourcePressed;
+            InteractionManager.InteractionSourceReleased += SourceReleased;
+            InteractionManager.InteractionSourceUpdated  += SourceUpdated;
 
-			// Setup voice control events
-			keywordRecognizer = new KeywordRecognizer(new string[] { "circle", "ball", "cube", "reset", "clear", "enable", "disable", "add", "up", "down", "white up", "white down", "save" });
-			keywordRecognizer.OnPhraseRecognized += HeardKeyword;
-			keywordRecognizer.Start();
-			#endif
+            // Setup voice control events
+            keywordRecognizer = new KeywordRecognizer(new string[] { "circle", "ball", "cube", "reset", "clear", "enable", "disable", "add", "up", "down", "white up", "white down", "save" });
+            keywordRecognizer.OnPhraseRecognized += HeardKeyword;
+            keywordRecognizer.Start();
+            #endif
 
-			// Setup scene objects
-			spheres    .SetActive(false);
-			shaderBalls.SetActive(true);
-			cubes      .SetActive(false);
-			
-			targetPos = transform.position;
-		
-			// Hook up resources
-			lightCapture = FindObjectOfType<LightCapture>();
+            // Setup scene objects
+            spheres    .SetActive(false);
+            shaderBalls.SetActive(true);
+            cubes      .SetActive(false);
 
-			// No hard dependence on the MRTK, just reflect into the parts we want to use
-			Type textToSpeechType = Type.GetType("HoloToolkit.Unity.TextToSpeech");
-			if (textToSpeechType != null)
-			{
-				tts = (Component)FindObjectOfType(textToSpeechType);
-				speakMethod = textToSpeechType.GetMethod("StartSpeaking");
-			}
-		}
-		private void OnDisable()
-		{
-			#if UNITY_EDITOR || WINDOWS_UWP
-			// Remove hand event hooks
-			InteractionManager.InteractionSourceLost     -= SourceLost;
-			InteractionManager.InteractionSourcePressed  -= SourcePressed;
-			InteractionManager.InteractionSourceReleased -= SourceReleased;
-			InteractionManager.InteractionSourceUpdated  -= SourceUpdated;
+            targetPos = transform.position;
 
-			keywordRecognizer.Stop();
-			keywordRecognizer = null;
-			#endif
-		}
+            // Hook up resources
+            lightCapture = FindObjectOfType<LightCapture>();
 
-		#if UNITY_EDITOR || WINDOWS_UWP
-		private void SourceLost(InteractionSourceLostEventArgs obj)
-		{
-			pressed = false;
-		}
-		private void SourceReleased(InteractionSourceReleasedEventArgs obj)
-		{
-			pressed = false;
-		}
-		private void SourcePressed(InteractionSourcePressedEventArgs obj)
-		{
-			pressed  = true;
+            // No hard dependence on the MRTK, just reflect into the parts we want to use
+            Type textToSpeechType = Type.GetType("HoloToolkit.Unity.TextToSpeech");
+            if (textToSpeechType != null)
+            {
+                tts = (Component)FindObjectOfType(textToSpeechType);
+                speakMethod = textToSpeechType.GetMethod("StartSpeaking");
+            }
+        }
+        private void OnDisable()
+        {
+            #if UNITY_EDITOR || WINDOWS_UWP
+            // Remove hand event hooks
+            InteractionManager.InteractionSourceLost     -= SourceLost;
+            InteractionManager.InteractionSourcePressed  -= SourcePressed;
+            InteractionManager.InteractionSourceReleased -= SourceReleased;
+            InteractionManager.InteractionSourceUpdated  -= SourceUpdated;
 
-			handVelocity = Vector3.zero;
-			lastPos      = handPos;
-			lastTime     = Time.time;
-		}
-		private void SourceUpdated(InteractionSourceUpdatedEventArgs obj)
-		{
-			if (obj.state.source.kind != InteractionSourceKind.Hand)
-			{
-				return;
-			}
+            keywordRecognizer.Stop();
+            keywordRecognizer = null;
+            #endif
+        }
 
-			Vector3 pos;
-			if (Time.time - lastTime > 0 && obj.state.sourcePose.TryGetPosition(out pos))
-			{
-				if (pressed)
-				{
-					handVelocity = (pos - lastPos) / (Time.time - lastTime);
-					if (handVelocity.sqrMagnitude > maxVelocity*maxVelocity)
-					{
-						handVelocity = handVelocity.normalized* maxVelocity;
-					}
-				}
+        #if UNITY_EDITOR || WINDOWS_UWP
+        private void SourceLost(InteractionSourceLostEventArgs obj)
+        {
+            pressed = false;
+        }
+        private void SourceReleased(InteractionSourceReleasedEventArgs obj)
+        {
+            pressed = false;
+        }
+        private void SourcePressed(InteractionSourcePressedEventArgs obj)
+        {
+            pressed  = true;
 
-				lastPos  = handPos;
-				lastTime = Time.time;
-				handPos  = pos;
-				
-				if (pressed)
-				{
-					targetPos += (pos - lastPos) * moveScale;
-				}
-			}
-		}
-	
-		private void HeardKeyword(PhraseRecognizedEventArgs args)
-		{
-			string reply = "ok";
+            handVelocity = Vector3.zero;
+            lastPos      = handPos;
+            lastTime     = Time.time;
+        }
+        private void SourceUpdated(InteractionSourceUpdatedEventArgs obj)
+        {
+            if (obj.state.source.kind != InteractionSourceKind.Hand)
+            {
+                return;
+            }
 
-			// Execute the command we just heard
-			if (args.text == "circle")
-			{
-				spheres.SetActive(true);
-				shaderBalls.SetActive(false);
-				cubes.SetActive(false);
-			}
-			else if (args.text == "ball")
-			{
-				spheres.SetActive(false);
-				shaderBalls.SetActive(true);
-				cubes.SetActive(false);
-			}
-			else if (args.text == "cube")
-			{
-				spheres.SetActive(false);
-				shaderBalls.SetActive(false);
-				cubes.SetActive(true);
-			}
-			else if (args.text == "reset")
-			{
-				transform.position = Camera.main.transform.position + Camera.main.transform.forward * 3;
-				transform.LookAt(Camera.main.transform.position);
-				transform.eulerAngles = new Vector3(0,transform.eulerAngles.y,0);
-				targetPos = transform.position;
-			}
-			else if (args.text == "clear")
-			{
-				lightCapture.Clear();
-			}
-			else if (args.text == "disable")
-			{
-				lightCapture.enabled = false;
-			}
-			else if (args.text == "enable")
-			{
-				lightCapture.enabled = true;
-			}
-			else if (args.text == "add")
-			{
-				RaycastHit hit;
-				if (UnityEngine.Physics.Raycast(Camera.main.transform.position, Camera.main.transform.forward, out hit))
-				{
-					GameObject prefab = spawnPrefabs[addIndex%spawnPrefabs.Length];
-					Instantiate(prefab, hit.point, prefab.transform.rotation);
-					addIndex++;
-				}
-			}
-			else if (args.text == "up")
-			{
-				exposure += 1;
-				lightCapture.SetExposure(exposure);
-				reply = ""+exposure;
-			}
-			else if (args.text == "down")
-			{
-				exposure -= 1;
-				lightCapture.SetExposure(exposure);
-				reply = ""+exposure;
-			}
-			else if (args.text == "white up")
-			{
-				whitebalance += 250;
-				lightCapture.SetWhitebalance(whitebalance);
-				Debug.Log("WB: " + whitebalance);
-				reply = ""+whitebalance;
-			}
-			else if (args.text == "white down")
-			{
-				whitebalance -= 250;
-				lightCapture.SetWhitebalance(whitebalance);
-				Debug.Log("WB: " + whitebalance);
-				reply = ""+whitebalance;
-			}
-			else if (args.text == "save")
-			{
-				#if WINDOWS_UWP
-				SaveMap();
-				reply = "Saving environment map to photo roll!";
-				#else
-				reply = "Saving to photo roll not supported on this platform.";
-				#endif
-			}
+            Vector3 pos;
+            if (Time.time - lastTime > 0 && obj.state.sourcePose.TryGetPosition(out pos))
+            {
+                if (pressed)
+                {
+                    handVelocity = (pos - lastPos) / (Time.time - lastTime);
+                    if (handVelocity.sqrMagnitude > maxVelocity*maxVelocity)
+                    {
+                        handVelocity = handVelocity.normalized* maxVelocity;
+                    }
+                }
 
-			// Output results of the command
-			Debug.Log("Heard command: " + args.text);
-			if (tts != null)
-			{
-				speakMethod.Invoke(tts, new object[] { reply });
-			}
-		}
-		#endif
+                lastPos  = handPos;
+                lastTime = Time.time;
+                handPos  = pos;
 
-		#if WINDOWS_UWP
-		private async void SaveMap()
-		{
-			Texture2D tex     = CubeMapper.CreateCubemapTex(lightCapture.CubeMapper.Map);
-			byte[]    texData = tex.EncodeToPNG();
+                if (pressed)
+                {
+                    targetPos += (pos - lastPos) * moveScale;
+                }
+            }
+        }
 
-			var picturesLibrary = await global::Windows.Storage.StorageLibrary.GetLibraryAsync(global::Windows.Storage.KnownLibraryId.Pictures);
-			// Fall back to the local app storage if the Pictures Library is not available
-			var captureFolder = picturesLibrary.SaveFolder ?? global::Windows.Storage.ApplicationData.Current.LocalFolder;
-			var file = await captureFolder.CreateFileAsync("EnvironmentMap.png", global::Windows.Storage.CreationCollisionOption.GenerateUniqueName);
-			await global::Windows.Storage.FileIO.WriteBytesAsync(file, texData);
-		}
-		#endif
+        private async void HeardKeyword(PhraseRecognizedEventArgs args)
+        {
+            string reply = "ok";
 
-		private void Update()
-		{
-			if (!pressed)
-			{
-				handVelocity = Vector3.Lerp(handVelocity, Vector3.zero, velocityDecay*Time.deltaTime);
-				targetPos   += handVelocity * Time.deltaTime;
-			}
-			else
-			{
-				// Blend rotation towards the player
-				Quaternion dest = Quaternion.LookRotation( transform.position-Camera.main.transform.position );
-				Vector3    rot  = dest.eulerAngles;
-				rot.x = rot.z = 0;
-				dest = Quaternion.Euler(rot);
+            // Execute the command we just heard
+            if (args.text == "circle")
+            {
+                spheres.SetActive(true);
+                shaderBalls.SetActive(false);
+                cubes.SetActive(false);
+            }
+            else if (args.text == "ball")
+            {
+                spheres.SetActive(false);
+                shaderBalls.SetActive(true);
+                cubes.SetActive(false);
+            }
+            else if (args.text == "cube")
+            {
+                spheres.SetActive(false);
+                shaderBalls.SetActive(false);
+                cubes.SetActive(true);
+            }
+            else if (args.text == "reset")
+            {
+                transform.position = Camera.main.transform.position + Camera.main.transform.forward * 3;
+                transform.LookAt(Camera.main.transform.position);
+                transform.eulerAngles = new Vector3(0,transform.eulerAngles.y,0);
+                targetPos = transform.position;
+            }
+            else if (args.text == "clear")
+            {
+                lightCapture.Clear();
+            }
+            else if (args.text == "disable")
+            {
+                lightCapture.enabled = false;
+            }
+            else if (args.text == "enable")
+            {
+                lightCapture.enabled = true;
+            }
+            else if (args.text == "add")
+            {
+                RaycastHit hit;
+                if (UnityEngine.Physics.Raycast(Camera.main.transform.position, Camera.main.transform.forward, out hit))
+                {
+                    GameObject prefab = spawnPrefabs[addIndex%spawnPrefabs.Length];
+                    Instantiate(prefab, hit.point, prefab.transform.rotation);
+                    addIndex++;
+                }
+            }
+            else if (args.text == "up")
+            {
+                if (exposure + EXPOSURE_ADJUST <= EXPOSURE_MAX)
+                {
+                    exposure += EXPOSURE_ADJUST;
+                    await lightCapture.SetExposureAsync(exposure);
+                }
+                reply = ""+exposure;
+            }
+            else if (args.text == "down")
+            {
+                if (exposure - EXPOSURE_ADJUST >= EXPOSURE_MIN)
+                {
+                    exposure -= EXPOSURE_ADJUST;
+                    await lightCapture.SetExposureAsync(exposure);
+                }
+                reply = ""+exposure;
+            }
+            else if (args.text == "white up")
+            {
+                whitebalance += WB_ADJUST;
+                await lightCapture.SetWhiteBalanceAsync(whitebalance);
+                Debug.Log("WB: " + whitebalance);
+                reply = ""+whitebalance;
+            }
+            else if (args.text == "white down")
+            {
+                whitebalance -= 250;
+                await lightCapture.SetWhiteBalanceAsync(whitebalance);
+                Debug.Log("WB: " + whitebalance);
+                reply = ""+whitebalance;
+            }
+            else if (args.text == "save")
+            {
+                #if WINDOWS_UWP
+                SaveMap();
+                reply = "Saving environment map to photo roll!";
+                #else
+                reply = "Saving to photo roll not supported on this platform.";
+                #endif
+            }
 
-				transform.rotation = Quaternion.Slerp(transform.rotation, dest, 4 * Time.deltaTime);
-			}
-			transform.position = Vector3.Lerp(transform.position, targetPos, Time.deltaTime * lerpSpeed);
-		}
-	}
+            // Output results of the command
+            Debug.Log("Heard command: " + args.text);
+            if (tts != null)
+            {
+                speakMethod.Invoke(tts, new object[] { reply });
+            }
+        }
+        #endif
+
+        #if WINDOWS_UWP
+        private async void SaveMap()
+        {
+            Texture2D tex     = CubeMapper.CreateCubemapTex(lightCapture.CubeMapper.Map);
+            byte[]    texData = tex.EncodeToPNG();
+
+            var picturesLibrary = await global::Windows.Storage.StorageLibrary.GetLibraryAsync(global::Windows.Storage.KnownLibraryId.Pictures);
+            // Fall back to the local app storage if the Pictures Library is not available
+            var captureFolder = picturesLibrary.SaveFolder ?? global::Windows.Storage.ApplicationData.Current.LocalFolder;
+            var file = await captureFolder.CreateFileAsync("EnvironmentMap.png", global::Windows.Storage.CreationCollisionOption.GenerateUniqueName);
+            await global::Windows.Storage.FileIO.WriteBytesAsync(file, texData);
+        }
+        #endif
+
+        private void Update()
+        {
+            if (!pressed)
+            {
+                handVelocity = Vector3.Lerp(handVelocity, Vector3.zero, velocityDecay*Time.deltaTime);
+                targetPos   += handVelocity * Time.deltaTime;
+            }
+            else
+            {
+                // Blend rotation towards the player
+                Quaternion dest = Quaternion.LookRotation( transform.position-Camera.main.transform.position );
+                Vector3    rot  = dest.eulerAngles;
+                rot.x = rot.z = 0;
+                dest = Quaternion.Euler(rot);
+
+                transform.rotation = Quaternion.Slerp(transform.rotation, dest, 4 * Time.deltaTime);
+            }
+            transform.position = Vector3.Lerp(transform.position, targetPos, Time.deltaTime * lerpSpeed);
+        }
+    }
 }

--- a/Assets/MixedRealityToolkit.LightingTools/LightCapture.cs
+++ b/Assets/MixedRealityToolkit.LightingTools/LightCapture.cs
@@ -1,144 +1,242 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Rendering;
 
 namespace Microsoft.MixedReality.Toolkit.LightingTools
 {
-	public class LightCapture : MonoBehaviour
-	{
-		#region Fields
-		[Header("Settings")]
-		[Tooltip("Resolution (pixels) per-face of the generated lighting Cubemap.")]
-		[SerializeField] private int mapResolution = 128;
-	
-		[Header("Stamp Optimizations")]
-		[Tooltip("Should the component only do the initial wraparound stamp? If true, only one picture will be taken, at the very beginning.")]
-		[SerializeField]              private bool  singleStampOnly     = false;
-		[Tooltip("When stamping a camera picture onto the Cubemap, scale it up by this so it covers a little more space. This can mean fewer total stamps needed to complete the Cubemap, at the expense of a less perfect reflection.")]
-		[SerializeField, Range(1, 2)] private float stampFovMultiplier  = 1f;
-		[Tooltip("This is the distance (meters) the camera must travel for a stamp to expire. When a stamp expires, the Camera will take another picture in that direction when given the opportunity. Zero means no expiration.")]
-		[SerializeField]              private float stampExpireDistance = 0;
+    public class LightCapture : MonoBehaviour, ICameraControl
+    {
+        #region Member Variables
+        /// <summary> Interface to the camera we're using. This is different on different platforms. </summary>
+        private ICameraCapture cameraCapture;
 
-		[Header("Directional Lighting")]
-		[Tooltip("Should the system calculate information for a directional light? This will scrape the lower mips of the Cubemap to find the direction and color of the brightest values, and apply it to the scene's light.")]
-		[SerializeField]             private bool  useDirectionalLight       = true;
-		[Tooltip("When finding the primary light color, it will average the brightest 20% of the pixels, and use that color for the light. This sets the cap for the saturation of that color.")]
-		[SerializeField, Range(0,1)] private float maxLightColorSaturation   = 0.3f;
-		[Tooltip("The light eases into its new location when the information is updated. This is the speed at which it eases to its new destination, measured in degrees per second.")]
-		[SerializeField]             private float lightAngleAdjustPerSecond = 45f;
+        /// <summary> Interface to control advanced camera settings, if supported. </summary>
+        private ICameraControl cameraControl;
 
-		[Header("Optional Overrides")]
-		[Tooltip("Defaults to Camera.main. Which object should we be looking at for our orientation and position?")]
-		[SerializeField] private Transform       cameraOrientation;
-		[Tooltip("Default will pick from the scene, or create one automatically. If you have settings you'd like to configure on your probe, hook it in here.")]
-		[SerializeField] private ReflectionProbe probe;
-		[Tooltip("Default will pick the first directional light in the scene. If no directional light is found, one will be created!")]
-		[SerializeField] private Light           directionalLight;
-	
-		/// <summary> Interface to the camera we're using. This is different on different platforms. </summary>
-		private ICameraCapture captureCamera;
-		/// <summary> The Cubemap tool we're using to generate the light information for Unity's probes. </summary>
-		private CubeMapper     map = null;
-		/// <summary> Histogram of the Cubemap's colors. Used for primary light source color calculations. </summary>
-		private Histogram      histogram = new Histogram();
-		/// <summary> Used to track the original skybox material, in case we want to disable light capture and restore state. </summary>
-		private Material       startSky;
-        private Quaternion     startLightRot;
-        private Color          startLightColor;
-        private float          startLightBrightness;
-		/// <summary> The number of stamps currently in our cubemap.  Used for singleStampOnly option. </summary>
-		private int            stampCount;
+        /// <summary> The Cubemap tool we're using to generate the light information for Unity's probes. </summary>
+        private CubeMapper map = null;
+        /// <summary> Histogram of the Cubemap's colors. Used for primary light source color calculations. </summary>
+        private Histogram histogram = new Histogram();
+        /// <summary> Used to track the original skybox material, in case we want to disable light capture and restore state. </summary>
+        private Material startSky;
+        private Quaternion startLightRot;
+        private Color startLightColor;
+        private float startLightBrightness;
+        /// <summary> The number of stamps currently in our cubemap.  Used for singleStampOnly option. </summary>
+        private int stampCount;
 
-		// For easing the light directions                  
-		private Quaternion lightTargetDir;
-		private Quaternion lightStartDir;
-		private float      lightStartTime = -1;
-		private float      lightTargetDuration;
+        // For easing the light directions
+        private Quaternion lightTargetDir;
+        private Quaternion lightStartDir;
+        private float lightStartTime = -1;
+        private float lightTargetDuration;
+        #endregion // Member Variables
 
-		/// <summary>
-		/// Direct access to the CubeMapper class we're using!
-		/// </summary>
-		public CubeMapper CubeMapper
-		{
-			get
-			{
-				return map;
-			}
-		}
-		#endregion
+        #region Unity Inspector Variables
+        [Header("Settings")]
+        [Tooltip("Resolution (pixels) per-face of the generated lighting Cubemap.")]
+        [SerializeField] private int mapResolution = 128;
 
-		#region Unity Events
-		private void Awake ()
-		{
-			// Save initial settings in case we wish to restore them
-			startSky = RenderSettings.skybox;
+        [Header("Stamp Optimizations")]
+        [Tooltip("Should the component only do the initial wraparound stamp? If true, only one picture will be taken, at the very beginning.")]
+        [SerializeField] private bool singleStampOnly = false;
+        [Tooltip("When stamping a camera picture onto the Cubemap, scale it up by this so it covers a little more space. This can mean fewer total stamps needed to complete the Cubemap, at the expense of a less perfect reflection.")]
+        [SerializeField, Range(1, 2)] private float stampFovMultiplier = 1f;
+        [Tooltip("This is the distance (meters) the camera must travel for a stamp to expire. When a stamp expires, the Camera will take another picture in that direction when given the opportunity. Zero means no expiration.")]
+        [SerializeField] private float stampExpireDistance = 0;
 
-			// Pick camera based on platform
-			#if WINDOWS_UWP && !UNITY_EDITOR
-			captureCamera = new CameraCaptureUWP();
-			#elif (UNITY_ANDROID || UNITY_IOS) && !UNITY_EDITOR
-			captureCamera = new CameraCaptureARFoundation();
-			#else
-			// On a desktop computer, or certain laptops, we may not have access to any cameras.
-			if (WebCamTexture.devices.Length <= 0)
-			{
-				// Alternatively, you can simulate a camera by taking screenshots instead.
-				// captureCamera = new CameraCaptureScreen(Camera.main);
+        [Header("Directional Lighting")]
+        [Tooltip("Should the system calculate information for a directional light? This will scrape the lower mips of the Cubemap to find the direction and color of the brightest values, and apply it to the scene's light.")]
+        [SerializeField] private bool useDirectionalLight = true;
+        [Tooltip("When finding the primary light color, it will average the brightest 20% of the pixels, and use that color for the light. This sets the cap for the saturation of that color.")]
+        [SerializeField, Range(0, 1)] private float maxLightColorSaturation = 0.3f;
+        [Tooltip("The light eases into its new location when the information is updated. This is the speed at which it eases to its new destination, measured in degrees per second.")]
+        [SerializeField] private float lightAngleAdjustPerSecond = 45f;
 
-				// When disabling and returning immediately, OnDisable will be called without
-				// OnEnable ever getting called.
-				enabled = false;
-				return;
-			}
-			else
-			{
-				captureCamera = new CameraCaptureWebcam(Camera.main.transform, Camera.main.fieldOfView);
-			}
-			#endif
+        [Header("Optional Overrides")]
+        [Tooltip("Defaults to Camera.main. Which object should we be looking at for our orientation and position?")]
+        [SerializeField] private Transform cameraOrientation;
+        [Tooltip("Default will pick from the scene, or create one automatically. If you have settings you'd like to configure on your probe, hook it in here.")]
+        [SerializeField] private ReflectionProbe probe;
+        [Tooltip("Default will pick the first directional light in the scene. If no directional light is found, one will be created!")]
+        [SerializeField] private Light directionalLight;
+        #endregion // Unity Inspector Variables
 
-			// Make sure we have access to a probe in the scene
-			if (probe == null) 
-			{
-				probe = FindObjectOfType<ReflectionProbe>();
-			}
-			if (probe == null)
-			{
-				GameObject probeObj = new GameObject("_LightCaptureProbe", typeof(ReflectionProbe));
-				probeObj.transform.SetParent(transform, false);
-				probe = probeObj.GetComponent<ReflectionProbe>();
-			
-				probe.size          = Vector3.one * 10000;
-				probe.boxProjection = false;
-			}
+        #region Private Methods
+        private async Task TakeStampAsync()
+        {
+            var result = await cameraCapture.RequestTextureAsync();
+            var texture = result.Texture;
+            var matrix = result.Matrix;
 
-			// Same with a camera object
-			if (cameraOrientation == null)
-			{
-				cameraOrientation = Camera.main.transform;
-			}
+            map.Stamp(texture, matrix.GetColumn(3), matrix.rotation, matrix.MultiplyVector(Vector3.forward));
+            stampCount += 1;
 
-			// And check for a directional light in the scene
-			if (useDirectionalLight && directionalLight == null)
-			{
-				Light[] lights = FindObjectsOfType<Light>();
-				for (int i = 0; i < lights.Length; i++)
-				{
-					if (lights[i].type == LightType.Directional)
-					{
-						directionalLight = lights[i];
-						break;
-					}
-				}
-				if (directionalLight == null)
-				{
-					GameObject lightObj = new GameObject("_DirectionalLight", typeof(Light));
-					lightObj.transform.SetParent(transform, false);
-					directionalLight = lightObj.GetComponent<Light>();
-					directionalLight.type = LightType.Directional;
-				}
-			}
+            DynamicGI.UpdateEnvironment();
+
+            if (useDirectionalLight)
+            {
+                UpdateDirectionalLight();
+            }
+        }
+
+        private void UpdateDirectionalLight()
+        {
+            if (directionalLight == null || map == null)
+            {
+                return;
+            }
+
+            // Calculate the light direction
+            Vector3 dir = map.GetWeightedDirection(ref histogram);
+            dir.y = Mathf.Abs(dir.y); // Don't allow upward facing lights! In many cases, 'light' from below is just a large surface that reflects from an overhead source
+
+            // Prevent zero vectors, Unity doesn't like them.
+            if (dir.sqrMagnitude < 0.000001f)
+                dir = Vector3.up;
+
+            if (lightStartTime < 0 || lightAngleAdjustPerSecond == 0)
+            {
+                directionalLight.transform.forward = -dir;
+                lightStartTime = 0;
+            }
+            else
+            {
+                lightTargetDir = Quaternion.LookRotation(-dir);
+                lightStartDir = directionalLight.transform.localRotation;
+                lightStartTime = Time.time;
+                lightTargetDuration = Quaternion.Angle(lightTargetDir, lightStartDir) / lightAngleAdjustPerSecond;
+
+                if (lightTargetDuration <= 0)
+                {
+                    directionalLight.transform.forward = -dir;
+                    lightStartTime = 0;
+                }
+            }
+
+            // Calculate a color and intensity from the cubemap's histogram
+
+            // grab the color for the brightest 20% of the image
+            float bright = histogram.FindPercentage(.8f);
+            Color color = histogram.GetColor(bright, 1);
+
+            // For the final color, we use a 'value' of 1, since we use the intensity for brightness of the light source.
+            // Also, light sources are rarely very saturated, so we cap that as well
+            float hue, sat, val;
+            Color.RGBToHSV(color, out hue, out sat, out val);
+            directionalLight.color = Color.HSVToRGB(hue, Mathf.Min(sat, maxLightColorSaturation), 1);
+            directionalLight.intensity = bright;
+        }
+
+        /// <summary>
+        /// Warns if the the current camera does not support advanced control.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if statement if a warning was generated; otherwise <c>false</c>.
+        /// </returns>
+        private bool WarnIfNoControl()
+        {
+            if (cameraControl == null)
+            {
+                Debug.LogWarning($"{nameof(LightCapture)} {name} - The current system does not support advanced camera control.");
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Warns if the system is not ready to perform an action.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if statement if a warning was generated; otherwise <c>false</c>.
+        /// </returns>
+        private bool WarnIfNotReady()
+        {
+            if (cameraCapture == null)
+            {
+                Debug.LogWarning($"{nameof(LightCapture)} {name} is not enabled or has not been initialized.");
+                return true;
+            }
+            return false;
+        }
+        #endregion
+
+        #region Unity Overrides
+        protected virtual void Awake ()
+        {
+            // Save initial settings in case we wish to restore them
+            startSky = RenderSettings.skybox;
+
+            // Pick camera based on platform
+            #if WINDOWS_UWP && !UNITY_EDITOR
+            cameraCapture = new CameraCaptureUWP();
+            #elif (UNITY_ANDROID || UNITY_IOS) && !UNITY_EDITOR
+            captureCamera = new CameraCaptureARFoundation();
+            #else
+            // On a desktop computer, or certain laptops, we may not have access to any cameras.
+            if (WebCamTexture.devices.Length <= 0)
+            {
+                // Alternatively, you can simulate a camera by taking screenshots instead.
+                // captureCamera = new CameraCaptureScreen(Camera.main);
+
+                // When disabling and returning immediately, OnDisable will be called without
+                // OnEnable ever getting called.
+                enabled = false;
+                return;
+            }
+            else
+            {
+                cameraCapture = new CameraCaptureWebcam(Camera.main.transform, Camera.main.fieldOfView);
+            }
+            #endif
+
+            // Try to get camera control as well
+            cameraControl = cameraCapture as ICameraControl;
+
+            // Make sure we have access to a probe in the scene
+            if (probe == null)
+            {
+                probe = FindObjectOfType<ReflectionProbe>();
+            }
+            if (probe == null)
+            {
+                GameObject probeObj = new GameObject("_LightCaptureProbe", typeof(ReflectionProbe));
+                probeObj.transform.SetParent(transform, false);
+                probe = probeObj.GetComponent<ReflectionProbe>();
+
+                probe.size          = Vector3.one * 10000;
+                probe.boxProjection = false;
+            }
+
+            // Same with a camera object
+            if (cameraOrientation == null)
+            {
+                cameraOrientation = Camera.main.transform;
+            }
+
+            // And check for a directional light in the scene
+            if (useDirectionalLight && directionalLight == null)
+            {
+                Light[] lights = FindObjectsOfType<Light>();
+                for (int i = 0; i < lights.Length; i++)
+                {
+                    if (lights[i].type == LightType.Directional)
+                    {
+                        directionalLight = lights[i];
+                        break;
+                    }
+                }
+                if (directionalLight == null)
+                {
+                    GameObject lightObj = new GameObject("_DirectionalLight", typeof(Light));
+                    lightObj.transform.SetParent(transform, false);
+                    directionalLight = lightObj.GetComponent<Light>();
+                    directionalLight.type = LightType.Directional;
+                }
+            }
 
             // Save initial light settings
             if (directionalLight != null)
@@ -147,18 +245,19 @@ namespace Microsoft.MixedReality.Toolkit.LightingTools
                 startLightRot        = directionalLight.transform.rotation;
                 startLightBrightness = directionalLight.intensity;
             }
-		}
-		private void OnDisable()
-		{
-			// Restore and render a default probe
-			if (probe != null && probe.isActiveAndEnabled)
-			{
-				probe.mode        = UnityEngine.Rendering.ReflectionProbeMode.Realtime;
-				probe.refreshMode = UnityEngine.Rendering.ReflectionProbeRefreshMode.ViaScripting;
-				probe.RenderProbe();
-			}
+        }
 
-			RenderSettings.skybox = startSky;
+        protected virtual void OnDisable()
+        {
+            // Restore and render a default probe
+            if (probe != null && probe.isActiveAndEnabled)
+            {
+                probe.mode        = UnityEngine.Rendering.ReflectionProbeMode.Realtime;
+                probe.refreshMode = UnityEngine.Rendering.ReflectionProbeRefreshMode.ViaScripting;
+                probe.RenderProbe();
+            }
+
+            RenderSettings.skybox = startSky;
 
             if (directionalLight != null)
             {
@@ -167,15 +266,16 @@ namespace Microsoft.MixedReality.Toolkit.LightingTools
                 directionalLight.intensity          = startLightBrightness;
             }
 
-            if (captureCamera != null)
-				captureCamera.Shutdown();
+            if (cameraCapture != null)
+                cameraCapture.Shutdown();
 
             DynamicGI.UpdateEnvironment();
         }
-		private void OnEnable()
-		{
-			// Save initial settings in case we wish to restore them
-			startSky = RenderSettings.skybox;
+
+        protected virtual async void OnEnable()
+        {
+            // Save initial settings in case we wish to restore them
+            startSky = RenderSettings.skybox;
             // Save initial light settings
             if (directionalLight != null)
             {
@@ -185,160 +285,115 @@ namespace Microsoft.MixedReality.Toolkit.LightingTools
                 UpdateDirectionalLight();
             }
 
-			probe.mode = UnityEngine.Rendering.ReflectionProbeMode.Custom;
-		
-			CameraResolution resolution = new CameraResolution();
-			resolution.nativeResolution = NativeResolutionMode.Smallest;
-			resolution.resize           = ResizeWhen.Never;
+            probe.mode = UnityEngine.Rendering.ReflectionProbeMode.Custom;
 
-			captureCamera.Initialize(true, resolution, ()=>
-			{
-				if (map == null)
-				{
-					map = new CubeMapper();
-					map.Create(captureCamera.FieldOfView * stampFovMultiplier, mapResolution);
-					map.StampExpireDistance = stampExpireDistance;
-				}
-				probe.customBakedTexture = map.Map;
-				RenderSettings.skybox = map.SkyMaterial;
-				RenderSettings.ambientMode = AmbientMode.Skybox;
-			});
+            CameraResolution resolution = new CameraResolution();
+            resolution.nativeResolution = NativeResolutionMode.Smallest;
+            resolution.resize           = ResizeWhen.Never;
+
+            await cameraCapture.InitializeAsync(true, resolution);
+
+            if (map == null)
+            {
+                map = new CubeMapper();
+                map.Create(cameraCapture.FieldOfView * stampFovMultiplier, mapResolution);
+                map.StampExpireDistance = stampExpireDistance;
+            }
+            probe.customBakedTexture = map.Map;
+            RenderSettings.skybox = map.SkyMaterial;
+            RenderSettings.ambientMode = AmbientMode.Skybox;
+
 
             DynamicGI.UpdateEnvironment();
         }
-		private void OnValidate()
-		{
-			if (map != null)
-			{
-				map.StampExpireDistance = stampExpireDistance;
-			}
-		}
 
-		private void Update ()
-		{
-			// ditch out if we already have our first stamp
-			if ((stampCount > 0 && singleStampOnly) )
-			{
-				return;
-			}
+        protected virtual void OnValidate()
+        {
+            if (map != null)
+            {
+                map.StampExpireDistance = stampExpireDistance;
+            }
+        }
 
-			// check the cache to see if our current orientation would benefit from a new stamp
-			if (captureCamera.IsReady && !captureCamera.IsRequestingImage)
-			{
-				if (!map.IsCached(cameraOrientation.position, cameraOrientation.forward))
-				{
-					captureCamera.RequestImage(OnReceivedImage);
-				}
-			}
+        protected virtual void Update ()
+        {
+            // ditch out if we already have our first stamp
+            if ((stampCount > 0 && singleStampOnly) )
+            {
+                return;
+            }
 
-			// If we have a target light rotation to get to, start lerping! 
-			if (lightStartTime > 0)
-			{
-				float t =  Mathf.Clamp01( (Time.time - lightStartTime) / lightTargetDuration );
-				if (t >= 1)
-				{
-					lightStartTime = 0;
-				}
-			
-				// This is a cheap cubic in/out easing function, so we aren't doing this linear (ew)
-				t = t<.5f ? 4*t*t*t : (t-1)*(2*t-2)*(2*t-2)+1; 
-				directionalLight.transform.localRotation = Quaternion.Lerp(lightStartDir, lightTargetDir, t);
-			}
-		}
-		#endregion
-	
-		#region Private Methods
-		private void OnReceivedImage(Texture texture, Matrix4x4 camera)
-		{
-			map.Stamp(texture, camera.GetColumn(3), camera.rotation, camera.MultiplyVector(Vector3.forward));
-			stampCount += 1;
+            // check the cache to see if our current orientation would benefit from a new stamp
+            if (map != null && cameraCapture.IsReady && !cameraCapture.IsRequestingImage)
+            {
+                if (!map.IsCached(cameraOrientation.position, cameraOrientation.forward))
+                {
+                    // Take stamp, but do not await. Let it run blindly so we don't block the
+                    // rest of our Update loop
+                    var t = TakeStampAsync();
+                }
+            }
 
-			DynamicGI.UpdateEnvironment();
+            // If we have a target light rotation to get to, start lerping!
+            if (lightStartTime > 0)
+            {
+                float t =  Mathf.Clamp01( (Time.time - lightStartTime) / lightTargetDuration );
+                if (t >= 1)
+                {
+                    lightStartTime = 0;
+                }
 
-			if (useDirectionalLight)
-			{
-				UpdateDirectionalLight();
-			}
-		}
-		private void UpdateDirectionalLight()
-		{
-			if (directionalLight == null || map == null)
-			{
-				return;
-			}
+                // This is a cheap cubic in/out easing function, so we aren't doing this linear (ew)
+                t = t<.5f ? 4*t*t*t : (t-1)*(2*t-2)*(2*t-2)+1;
+                directionalLight.transform.localRotation = Quaternion.Lerp(lightStartDir, lightTargetDir, t);
+            }
+        }
+        #endregion // Unity Overrides
 
-			// Calculate the light direction
-			Vector3 dir = map.GetWeightedDirection(ref histogram);
-			dir.y = Mathf.Abs(dir.y); // Don't allow upward facing lights! In many cases, 'light' from below is just a large surface that reflects from an overhead source
+        #region Public Methods
+        /// <inheritdoc/>
+        public Task SetExposureAsync(double exposure)
+        {
+            if (WarnIfNotReady()) { return Task.CompletedTask; }
+            if (WarnIfNoControl()) { return Task.CompletedTask; }
+            return cameraControl.SetExposureAsync(exposure);
+        }
 
-			// Prevent zero vectors, Unity doesn't like them.
-			if (dir.sqrMagnitude < 0.000001f)
-				dir = Vector3.up;
+        /// <inheritdoc/>
+        public Task SetWhiteBalanceAsync(uint temperature)
+        {
+            if (WarnIfNotReady()) { return Task.CompletedTask; }
+            if (WarnIfNoControl()) { return Task.CompletedTask; }
+            return cameraControl.SetWhiteBalanceAsync(temperature);
+        }
 
-			if (lightStartTime < 0 || lightAngleAdjustPerSecond == 0)
-			{
-				directionalLight.transform.forward = -dir;
-				lightStartTime = 0;
-			}
-			else 
-			{
-				lightTargetDir = Quaternion.LookRotation( -dir );
-				lightStartDir  = directionalLight.transform.localRotation;
-				lightStartTime = Time.time;
-				lightTargetDuration = Quaternion.Angle(lightTargetDir, lightStartDir) / lightAngleAdjustPerSecond;
-			
-				if (lightTargetDuration <= 0)
-				{
-					directionalLight.transform.forward = -dir;
-					lightStartTime = 0;
-				}
-			}
+        /// <inheritdoc/>
+        public Task SetISOAsync(uint iso)
+        {
+            if (WarnIfNotReady()) { return Task.CompletedTask; }
+            if (WarnIfNoControl()) { return Task.CompletedTask; }
+            return cameraControl.SetISOAsync(iso);
+        }
 
-			// Calculate a color and intensity from the cubemap's histogram
+        /// <summary> Clear the internal representation of light, and start over again from scratch. </summary>
+        public void Clear()
+        {
+            if (map != null) { map.Clear(); }
+            stampCount = 0;
+        }
+        #endregion
 
-			// grab the color for the brightest 20% of the image
-			float bright = histogram.FindPercentage(.8f);
-			Color color  = histogram.GetColor(bright, 1); 
-
-			// For the final color, we use a 'value' of 1, since we use the intensity for brightness of the light source.
-			// Also, light sources are rarely very saturated, so we cap that as well
-			float hue, sat, val;
-			Color.RGBToHSV(color, out hue, out sat, out val);
-			directionalLight.color = Color.HSVToRGB(hue, Mathf.Min(sat, maxLightColorSaturation), 1);
-			directionalLight.intensity = bright;
-		}
-		#endregion
-
-		#region Public Methods
-		/// <summary> On UWP platforms, this will let you set the exposure of the active camera. Uncertain of the units, but try values in the range of -10 -> +10 </summary>
-		public void SetExposure(int exp)
-		{
-			#if WINDOWS_UWP
-			CameraCaptureUWP cam = captureCamera as CameraCaptureUWP;
-			if (cam != null)
-			{
-				cam.Exposure = exp;
-			}
-			#endif
-		}
-		/// <summary> On UWP platforms, this will let you set the white balance of the active camera. Units are in (K) Kelvin, try values 1000 -> 10,000 </summary>
-		public void SetWhitebalance(int wb)
-		{
-			#if WINDOWS_UWP
-			CameraCaptureUWP cam = captureCamera as CameraCaptureUWP;
-			if (cam != null)
-			{
-				cam.Whitebalance = wb;
-			}
-			#endif
-		}
-
-		/// <summary> Clear the internal representation of light, and start over again from scratch. </summary>
-		public void Clear()
-		{
-			map.Clear();
-			stampCount = 0;
-		}
-		#endregion
-	}
+        #region Public Properties
+        /// <summary>
+        /// Direct access to the CubeMapper class we're using!
+        /// </summary>
+        public CubeMapper CubeMapper
+        {
+            get
+            {
+                return map;
+            }
+        }
+        #endregion // Public Properties
+    }
 }


### PR DESCRIPTION
This is a pretty big PR so I want to fully document the reason for each of the changes.

### Main Work

I started this work because I could not get MRLT to work on HoloLens 2 without errors in the Unity log and on screen. The most prominent errors were:

```
HoloLens locatable camera has failed to set auto exposure off
HoloLens locatable camera has failed to set exposure to ## as requested
HoloLens locatable camera has failed to set auto WhiteBalance off
HoloLens locatable camera has failed to set WhiteBalance to #### as requested
[CameraCapture] Can't get camera matrix!!
```

It turned out that these errors are primarily due to HoloLens 2 wanting to use [ExposureControl](https://docs.microsoft.com/en-us/uwp/api/windows.media.devices.videodevicecontroller.exposurecontrol?view=winrt-19041) rather than [Exposure](https://docs.microsoft.com/en-us/uwp/api/windows.media.devices.videodevicecontroller.exposure?view=winrt-19041) and wanting to use [WhiteBalanceControl](https://docs.microsoft.com/en-us/uwp/api/windows.media.devices.videodevicecontroller.whitebalancecontrol?view=winrt-19041) rather than [WhiteBalance](https://docs.microsoft.com/en-us/uwp/api/windows.media.devices.videodevicecontroller.whitebalance?view=winrt-19041).

My first attempts at fixing this looked promising, but seemed to only work randomly. Now I started seeing new errors in the log:

```
HoloLens locatable camera has failed to set exposure to 00:00:00.0101000. System.NullReferenceException: Object reference not set to an instance of an object.
HoloLens locatable camera has failed to set ISO to 80. System.ArgumentException: No capture devices are available.
```

These ended up stemming from two different core issues:

1. In HoloLens 2, the Control interfaces can only be adjusted while the camera is streaming.
1. It turned out there were several possible race conditions when setting these values (due to callbacks) and when shutting down or starting LightCapture back up.

Only adjusting the control values while streaming was a fairly easy fix. Apply them only if the camera is running, otherwise cache the values for the next time the camera is started.

The race conditions and callbacks ended up being responsible for the bulk of the refactoring. The root of the problem is that methods like `Initialize`, `SetExposure` and `SetWhiteBalance` all returned `void`, but internally they ran a bunch of callbacks. This made those methods function like `async void`. Now, I'm not going to say that `async void` should _never_ be used, but it tends to be the source of many headaches, race conditions and threading bugs. This is because the caller has no way to know when the function has actually completed. For more information see [Avoid Async Void](https://docs.microsoft.com/en-us/archive/msdn-magazine/2013/march/async-await-best-practices-in-asynchronous-programming#avoid-async-void).

It's also worth pointing out that any method that returns a `Task` can be treated as `void`, just not the other way around. 

The following line:

`var t = SetWhiteBalanceAsync(5000);`

Is functionally equivalent to:

`SetWhiteBalance(5000, myCallback);`

If `Task` t is never awaited, it will run in the background and we'll never know whether it failed or completed. This would be equivalent to `myCallback` never getting called but the application being unaware it didn't happen.

So, every method in the library that previously used a callback was converted to return a `Task`. And every place that called one of those methods was also converted to a `Task` (whenever possible). There were a few cases where this wasn't possible. For example, when responding to a UI button click. In these "last mile" cases `async void` was used, but error handlers were employed.


### Other Fixes and Changes

Those are the main things that were refactored. In addition there were also other fixes and improvements which I'll cover now:

- Originally, code to change Exposure, White Balance and ISO was conditionally compiled to only run with UWP. I created a new interface `ICameraControl` that any camera controller on any platform can implement. Currently only UWP does, but the example now checks for this interface and will use it if available.

- In the `NativeArray<Color24>` method of `CameraCaptureWebcam` there was a blind cast of `resizedTexture` to `Texture2D`. However, at least on my system `resizedTexture` is a `WebCamTexture` which does not inherit from `Texture2D`. This would have resulted in an `InvalidCastException`. For now I changed this to an `As` instead of a hard cast and throw an `UnsupportedException` with a clear message if the conversion can't be done.

- In `LightCapture.Update`, the `Map` was being used before the camera had fully completed initializing. The reason this wasn't an error before was probably again due to callbacks. The camera was probably partially initialized (up to the first callback) but not completely initialized. This became apparent when initialization became a `Task` and that `Task` did not complete until the device was fully initialized. The fix was a simple check to make sure `Map` is not null before reading it.

- `CameraCaptureWebcam` start delay was updated from 0.5 seconds to 2.0. I have a Logitech BRIO and it takes much longer than 0.5 seconds to initialize.

- The range values for Exposure of -10 to 10 did not work for all devices and did not map easily to the new Control interfaces. I changed Exposure to a floating point value ranging from 0.0 to 1.0. This allows me to directly map the values to the Min and Max values returned by the Controller. It can also be easily converted back to the -10 to 10 range for the old Exposure interface.

- ISO of 80 was way too dark. From reading online, it looks like this was probably supposed to be 800 and not 80 so I changed it to 800. This was probably never caught because I don't think ISO was actually ever successfully set before. ISO Control can only be adjusted while streaming.

- Upped the exposure from 0.17 to 0.2 (equivalent of changing from -7 to -6). This was due to getting ISO working. An ISO of 800 is recommended for indoors, but the exposure at this ISO was a little too dark. This new default looks good on HoloLens 2.

- Added Min and Max values for Exposure, ISO and White Balance to the Example scene. 

- Converted voice commands in the Example scene to constants so they couldn't get out of sync.

- Added voice commands to the Example scene to allow for adjusting ISO.